### PR TITLE
chore: v0.2.0-alpha リリース

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ## [Unreleased]
 
+## [v0.2.0-alpha] - 2026-02-25
+
 ### Added
 
 - `sys update` / `repo update` / `repo cleanup` / `dsx run` に `--log-file` フラグを追加（ジョブ実行ログをファイルに保存）
@@ -196,5 +198,6 @@
 
 ---
 
-[Unreleased]: https://github.com/scottlz0310/dsx/compare/v0.1.0-alpha...HEAD
+[Unreleased]: https://github.com/scottlz0310/dsx/compare/v0.2.0-alpha...HEAD
+[v0.2.0-alpha]: https://github.com/scottlz0310/dsx/compare/v0.1.0-alpha...v0.2.0-alpha
 [v0.1.0-alpha]: https://github.com/scottlz0310/dsx/releases/tag/v0.1.0-alpha


### PR DESCRIPTION
## v0.2.0-alpha リリース

CHANGELOG.md の `[Unreleased]` セクションを `[v0.2.0-alpha]` に昇格させます。

マージ後に `v0.2.0-alpha` タグをプッシュして GoReleaser による自動リリースを開始します。

### 主な変更内容（前バージョン v0.1.0-alpha からの差分）

**破壊的変更**
- ツール名・リポジトリ名を `devsync` → `dsx` に変更（バイナリ名・設定パス・環境変数プレフィックス全て移行）

**シェル統合関数のリデザイン**
- `dsx-env`: Bitwarden 自動アンロック + 環境変数注入を1コマンドで実現
- `dsx-sys` / `dsx-repo` / `dsx-run`: 各操作を単独実行できる関数を追加

**機能追加**
- 多数のパッケージマネージャ対応追加（flatpak, fwupdmgr, pnpm, nvm, uv, rustup, gem, winget, scoop）
- TUI 進捗表示・`--log-file` フラグ・`config show/validate` 等

**バグ修正・改善**
- Windows/PowerShell 互換性の大幅改善
- GitHub レート制限対応
- Bitwarden 未ログイン検知の即時化