### PR TITLE
v0.2.1-alpha リリース準備

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ## [Unreleased]
 
+## [v0.2.1-alpha] - 2026-02-26
+
 ### Added
 
 - `dsx self-update` サブコマンドを追加（`--check` で更新確認のみ実行可能）
@@ -13,7 +15,7 @@
 ### Changed
 
 - `dsx run` / `dsx sys update` の終了時に、`dsx` 本体の更新がある場合のみ最後に通知するよう改善
-- `task lint` と CI の lint 実行を `go run .../golangci-lint@latest` に統一し、Go バージョン不一致による失敗を回避
+- `task lint` と CI の lint 実行を `go run .../golangci-lint/v2/...@latest` に統一し、Go バージョン不一致による失敗を回避
 
 ## [v0.2.0-alpha] - 2026-02-25
 
@@ -207,6 +209,7 @@
 
 ---
 
-[Unreleased]: https://github.com/scottlz0310/dsx/compare/v0.2.0-alpha...HEAD
+[Unreleased]: https://github.com/scottlz0310/dsx/compare/v0.2.1-alpha...HEAD
+[v0.2.1-alpha]: https://github.com/scottlz0310/dsx/compare/v0.2.0-alpha...v0.2.1-alpha
 [v0.2.0-alpha]: https://github.com/scottlz0310/dsx/compare/v0.1.0-alpha...v0.2.0-alpha
 [v0.1.0-alpha]: https://github.com/scottlz0310/dsx/releases/tag/v0.1.0-alpha

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ dsx は、開発環境の運用作業を統合・一元化するためのクロ�
 [Releases ページ](https://github.com/scottlz0310/dsx/releases) からお使いの OS 向けのバイナリをダウンロードして PATH に配置してください。
 
 ```bash
-# 例: Linux amd64（v0.2.0 の場合）
-curl -Lo dsx.tar.gz https://github.com/scottlz0310/dsx/releases/download/v0.2.0/dsx_0.2.0_linux_amd64.tar.gz
+# 例: Linux amd64（v0.2.1-alpha の場合）
+curl -Lo dsx.tar.gz https://github.com/scottlz0310/dsx/releases/download/v0.2.1-alpha/dsx_0.2.1-alpha_linux_amd64.tar.gz
 tar xzf dsx.tar.gz
 sudo mv dsx /usr/local/bin/
 ```
@@ -156,7 +156,7 @@ Remove-Item -Force (Get-Command dsx).Source
 
 ### メインコマンド
 ```
-dsx --version      # バージョン表示（現在: v0.1.0-alpha）
+dsx --version      # バージョン表示（現在: v0.2.1-alpha）
 dsx run           # 日次の統合タスクを実行（Bitwarden解錠→環境変数読込→更新処理）
 dsx run -n        # ドライラン（sys/repo に伝播）
 dsx run --tui     # TUI 進捗表示を有効化（sys/repo に伝播）
@@ -231,7 +231,7 @@ dsx config validate   # 設定内容を検証
 dsx config uninstall  # シェル設定からdsxを削除
 ```
 
-## 🚧 Alpha リリース方針（v0.1.0-alpha）
+## 🚧 Alpha リリース方針（v0.2.1-alpha）
 
 本バージョンは **運用検証向け Alpha** です。安定化期間中は `setup-repo` との併用を推奨します。
 
@@ -428,8 +428,8 @@ task snapshot       # スナップショットビルド（ローカル検証用�
 `v*` タグをプッシュすると GitHub Actions で自動リリースされます。
 
 ```bash
-git tag v0.2.0
-git push origin v0.2.0
+git tag v0.2.1-alpha
+git push origin v0.2.1-alpha
 ```
 
 ### Windows で `task lint` が gofmt で落ちる場合
@@ -455,7 +455,7 @@ task lint
 
 ## 📅 ステータス
 
-現在 **v0.1.0-alpha（運用検証フェーズ）** です。
+現在 **v0.2.1-alpha（運用検証フェーズ）** です。
 詳細なロードマップについては [docs/Implementation_Plan.md](docs/Implementation_Plan.md) を参照してください。
 
 ## 📄 ライセンス

--- a/tasks.md
+++ b/tasks.md
@@ -160,4 +160,5 @@
     - [x] `dsx run`（将来 `tool update`）への進捗UI適用
     - [ ] ~~通知機能向けイベントフックの追加~~ (見送り: 通知機能と合わせて見送り)
 - [x] `dsx run` / `dsx sys update` の完了時に `dsx` 本体更新通知を末尾表示し、`dsx self-update` サブコマンドを追加
-- [x] lint 実行を Go バージョン整合で安定化（Taskfile/CI ともに `go run .../golangci-lint@latest` へ統一）
+- [x] lint 実行を Go バージョン整合で安定化（Taskfile/CI ともに `go run .../golangci-lint/v2/...@latest` へ統一）
+- [x] `v0.2.1-alpha` リリース向けに README / CHANGELOG の更新とタグ運用手順を反映


### PR DESCRIPTION
## 概要
- `CHANGELOG.md` の Unreleased を `v0.2.1-alpha` として確定
- `README.md` のバージョン表記・ダウンロード例・タグ例を `v0.2.1-alpha` に更新
- `tasks.md` にリリース反映タスクを追記

## 確認
- `task check`
- `go build ./...`

このPRをマージ後、`v0.2.1-alpha` タグを push してリリースを発行します。