### PR TITLE
go install導線のバージョン表示修正とv0.2.2-alphaリリース準備

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@
 
 ## [Unreleased]
 
+## [v0.2.2-alpha] - 2026-02-26
+
+### Changed
+
+- `dsx --version` が `-ldflags` 未注入時でも `debug.ReadBuildInfo().Main.Version` からバージョン表示できるように改善（`go install ...@latest` 導線を改善）
+- `self-update` の開発ビルド判定に `(devel)` を追加し、開発ビルドでは更新比較をスキップする挙動を安定化
+
 ## [v0.2.1-alpha] - 2026-02-26
 
 ### Added
@@ -209,7 +216,8 @@
 
 ---
 
-[Unreleased]: https://github.com/scottlz0310/dsx/compare/v0.2.1-alpha...HEAD
+[Unreleased]: https://github.com/scottlz0310/dsx/compare/v0.2.2-alpha...HEAD
+[v0.2.2-alpha]: https://github.com/scottlz0310/dsx/compare/v0.2.1-alpha...v0.2.2-alpha
 [v0.2.1-alpha]: https://github.com/scottlz0310/dsx/compare/v0.2.0-alpha...v0.2.1-alpha
 [v0.2.0-alpha]: https://github.com/scottlz0310/dsx/compare/v0.1.0-alpha...v0.2.0-alpha
 [v0.1.0-alpha]: https://github.com/scottlz0310/dsx/releases/tag/v0.1.0-alpha

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ dsx は、開発環境の運用作業を統合・一元化するためのクロ�
 [Releases ページ](https://github.com/scottlz0310/dsx/releases) からお使いの OS 向けのバイナリをダウンロードして PATH に配置してください。
 
 ```bash
-# 例: Linux amd64（v0.2.1-alpha の場合）
-curl -Lo dsx.tar.gz https://github.com/scottlz0310/dsx/releases/download/v0.2.1-alpha/dsx_0.2.1-alpha_linux_amd64.tar.gz
+# 例: Linux amd64（v0.2.2-alpha の場合）
+curl -Lo dsx.tar.gz https://github.com/scottlz0310/dsx/releases/download/v0.2.2-alpha/dsx_0.2.2-alpha_linux_amd64.tar.gz
 tar xzf dsx.tar.gz
 sudo mv dsx /usr/local/bin/
 ```
@@ -46,6 +46,7 @@ go install github.com/scottlz0310/dsx/cmd/dsx@latest
 `$GOPATH/bin`（通常は `~/go/bin`）に `dsx` が配置されます。  
 PATH未設定の場合は、シェルの設定ファイルに追加してください。
 
+`dsx --version` は、`-ldflags` 未注入ビルド時でもモジュールのビルド情報からバージョン表示を試みます。
 ```bash
 export PATH="$HOME/go/bin:$PATH"
 ```
@@ -156,7 +157,7 @@ Remove-Item -Force (Get-Command dsx).Source
 
 ### メインコマンド
 ```
-dsx --version      # バージョン表示（現在: v0.2.1-alpha）
+dsx --version      # バージョン表示（現在: v0.2.2-alpha）
 dsx run           # 日次の統合タスクを実行（Bitwarden解錠→環境変数読込→更新処理）
 dsx run -n        # ドライラン（sys/repo に伝播）
 dsx run --tui     # TUI 進捗表示を有効化（sys/repo に伝播）
@@ -231,7 +232,7 @@ dsx config validate   # 設定内容を検証
 dsx config uninstall  # シェル設定からdsxを削除
 ```
 
-## 🚧 Alpha リリース方針（v0.2.1-alpha）
+## 🚧 Alpha リリース方針（v0.2.2-alpha）
 
 本バージョンは **運用検証向け Alpha** です。安定化期間中は `setup-repo` との併用を推奨します。
 
@@ -428,8 +429,8 @@ task snapshot       # スナップショットビルド（ローカル検証用�
 `v*` タグをプッシュすると GitHub Actions で自動リリースされます。
 
 ```bash
-git tag v0.2.1-alpha
-git push origin v0.2.1-alpha
+git tag v0.2.2-alpha
+git push origin v0.2.2-alpha
 ```
 
 ### Windows で `task lint` が gofmt で落ちる場合
@@ -455,7 +456,7 @@ task lint
 
 ## 📅 ステータス
 
-現在 **v0.2.1-alpha（運用検証フェーズ）** です。
+現在 **v0.2.2-alpha（運用検証フェーズ）** です。
 詳細なロードマップについては [docs/Implementation_Plan.md](docs/Implementation_Plan.md) を参照してください。
 
 ## 📄 ライセンス

--- a/cmd/dsx/root.go
+++ b/cmd/dsx/root.go
@@ -3,6 +3,8 @@ package main
 import (
 	"fmt"
 	"os"
+	"runtime/debug"
+	"strings"
 
 	"github.com/scottlz0310/dsx/internal/config"
 	"github.com/spf13/cobra"
@@ -64,8 +66,32 @@ func Execute() {
 }
 
 func init() {
+	version = resolveVersion(version)
+	rootCmd.Version = version
+
 	cobra.OnInitialize(initConfig)
 }
+
+func resolveVersion(currentVersion string) string {
+	trimmed := strings.TrimSpace(currentVersion)
+	if !isDevelopmentBuildVersion(trimmed) {
+		return trimmed
+	}
+
+	info, ok := readBuildInfoStep()
+	if !ok || info == nil {
+		return trimmed
+	}
+
+	buildVersion := strings.TrimSpace(info.Main.Version)
+	if buildVersion == "" {
+		return trimmed
+	}
+
+	return buildVersion
+}
+
+var readBuildInfoStep = debug.ReadBuildInfo
 
 func initConfig() {
 	// 設定ファイルが存在しない場合（初回実行時など）はエラーを無視して続行

--- a/cmd/dsx/root_test.go
+++ b/cmd/dsx/root_test.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"runtime/debug"
+	"testing"
+)
+
+func TestResolveVersion(t *testing.T) {
+	originalReadBuildInfo := readBuildInfoStep
+	t.Cleanup(func() {
+		readBuildInfoStep = originalReadBuildInfo
+	})
+
+	testCases := []struct {
+		name           string
+		currentVersion string
+		buildInfo      *debug.BuildInfo
+		buildInfoOK    bool
+		wantVersion    string
+		wantReadCall   bool
+	}{
+		{
+			name:           "ldflags注入済みはそのまま利用",
+			currentVersion: "v0.2.2-alpha",
+			buildInfo:      &debug.BuildInfo{Main: debug.Module{Version: "v9.9.9"}},
+			buildInfoOK:    true,
+			wantVersion:    "v0.2.2-alpha",
+			wantReadCall:   false,
+		},
+		{
+			name:           "dev版はbuildinfoのバージョンへフォールバック",
+			currentVersion: "dev",
+			buildInfo:      &debug.BuildInfo{Main: debug.Module{Version: "v0.2.2-alpha"}},
+			buildInfoOK:    true,
+			wantVersion:    "v0.2.2-alpha",
+			wantReadCall:   true,
+		},
+		{
+			name:           "devel版はbuildinfoが取れなければそのまま",
+			currentVersion: "(devel)",
+			buildInfoOK:    false,
+			wantVersion:    "(devel)",
+			wantReadCall:   true,
+		},
+		{
+			name:           "buildinfoのバージョン空文字はそのまま",
+			currentVersion: "dev",
+			buildInfo:      &debug.BuildInfo{Main: debug.Module{Version: ""}},
+			buildInfoOK:    true,
+			wantVersion:    "dev",
+			wantReadCall:   true,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			readCalled := false
+			readBuildInfoStep = func() (*debug.BuildInfo, bool) {
+				readCalled = true
+				return tc.buildInfo, tc.buildInfoOK
+			}
+
+			got := resolveVersion(tc.currentVersion)
+			if got != tc.wantVersion {
+				t.Fatalf("resolveVersion(%q) = %q, want %q", tc.currentVersion, got, tc.wantVersion)
+			}
+
+			if readCalled != tc.wantReadCall {
+				t.Fatalf("readBuildInfoStep called = %v, want %v", readCalled, tc.wantReadCall)
+			}
+		})
+	}
+}

--- a/cmd/dsx/self_update.go
+++ b/cmd/dsx/self_update.go
@@ -221,7 +221,7 @@ func applySelfUpdate(ctx context.Context) error {
 
 func isDevelopmentBuildVersion(v string) bool {
 	trimmed := strings.TrimSpace(v)
-	return trimmed == "" || trimmed == "dev"
+	return trimmed == "" || trimmed == "dev" || trimmed == "(devel)"
 }
 
 func parseSemverCore(v string) (semverCore, bool) {

--- a/cmd/dsx/self_update_test.go
+++ b/cmd/dsx/self_update_test.go
@@ -122,6 +122,49 @@ func TestCompareSemverCore(t *testing.T) {
 	}
 }
 
+func TestIsDevelopmentBuildVersion(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{
+			name:  "devは開発版",
+			input: "dev",
+			want:  true,
+		},
+		{
+			name:  "develは開発版",
+			input: "(devel)",
+			want:  true,
+		},
+		{
+			name:  "空文字は開発版",
+			input: "",
+			want:  true,
+		},
+		{
+			name:  "タグ版は開発版ではない",
+			input: "v0.2.2-alpha",
+			want:  false,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := isDevelopmentBuildVersion(tc.input)
+			if got != tc.want {
+				t.Fatalf("isDevelopmentBuildVersion(%q) = %v, want %v", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestCheckSelfUpdateAvailable(t *testing.T) {
 	originalFetch := selfUpdateFetchReleaseStep
 	t.Cleanup(func() {

--- a/tasks.md
+++ b/tasks.md
@@ -162,3 +162,4 @@
 - [x] `dsx run` / `dsx sys update` の完了時に `dsx` 本体更新通知を末尾表示し、`dsx self-update` サブコマンドを追加
 - [x] lint 実行を Go バージョン整合で安定化（Taskfile/CI ともに `go run .../golangci-lint/v2/...@latest` へ統一）
 - [x] `v0.2.1-alpha` リリース向けに README / CHANGELOG の更新とタグ運用手順を反映
+- [x] `go install ...@latest` でも `dsx --version` が実バージョンを表示できるようフォールバック実装し、`v0.2.2-alpha` リリース準備を反映


### PR DESCRIPTION
## 概要
- `go install github.com/scottlz0310/dsx/cmd/dsx@latest` で導入した場合でも、`dsx --version` が `dev` 固定にならないよう修正しました。
- `v0.2.2-alpha` リリース向けに README / CHANGELOG / tasks を更新しました。

## 変更内容
- `cmd/dsx/root.go`
  - 起動時に `resolveVersion()` を実行し、`version` が開発値の場合は `debug.ReadBuildInfo().Main.Version` へフォールバック
  - `rootCmd.Version` を解決済みバージョンで上書き
- `cmd/dsx/self_update.go`
  - 開発ビルド判定に `(devel)` を追加
- テスト追加/更新
  - `cmd/dsx/root_test.go` を追加（フォールバック解決の table-driven test）
  - `cmd/dsx/self_update_test.go` に開発ビルド判定テストを追加
- ドキュメント更新
  - `README.md` のバージョン表記を `v0.2.2-alpha` に更新
  - `CHANGELOG.md` に `v0.2.2-alpha` セクション追加
  - `tasks.md` の進捗を更新

## 検証
- `task check`
- `go build ./...`

## マージ後
- `main` 先頭で `v0.2.2-alpha` タグを push すればそのままリリース実行可能です。