### PR TITLE
feat(updater): GoBinaryInfo構造体とParseGoBinaryInfo実装、ParseGoVersionOutput廃止 (#45)

### DIFF
--- a/internal/updater/go.go
+++ b/internal/updater/go.go
@@ -220,7 +220,7 @@ type GoBinaryInfo struct {
 	PackagePath      string // `path` 行 → go install に使う
 	ModulePath       string // `mod` 行フィールド2（モジュールルート）
 	InstalledVersion string // `mod` 行フィールド3
-	GoVersion        string
+	GoVersion        string // ParseGoBinaryInfo では設定しない（将来タスクで対応予定）
 }
 
 // UpdateTarget は go install に渡すパスを返す（PackagePath + "@latest"）。
@@ -261,6 +261,10 @@ func ParseGoBinaryInfo(binaryPath, output string) (*GoBinaryInfo, error) {
 
 	if !foundPath {
 		return nil, fmt.Errorf("go version -m の出力に path 行が見つかりませんでした: %s", binaryPath)
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("go version -m 出力のスキャン中にエラーが発生しました: %w", err)
 	}
 
 	return info, nil

--- a/internal/updater/go.go
+++ b/internal/updater/go.go
@@ -225,8 +225,9 @@ type GoBinaryInfo struct {
 
 // UpdateTarget は go install に渡すパスを返す（PackagePath + "@latest"）。
 // フィールドではなくメソッドにすることで PackagePath との不整合を防ぐ。
+// レシーバが nil の場合は空文字を返す。
 func (i *GoBinaryInfo) UpdateTarget() string {
-	if i.PackagePath == "" {
+	if i == nil || i.PackagePath == "" {
 		return ""
 	}
 

--- a/internal/updater/go.go
+++ b/internal/updater/go.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"github.com/scottlz0310/dsx/internal/config"
@@ -212,26 +213,55 @@ func ListInstalledGoTools() ([]string, error) {
 	return tools, nil
 }
 
-// ParseGoVersionOutput は "go version -m <binary>" の出力からモジュールパスを取得します。
-func ParseGoVersionOutput(output string) (modulePath, version string) {
+// GoBinaryInfo は "go version -m <binary>" の出力から取得したバイナリ情報を保持します。
+type GoBinaryInfo struct {
+	BinaryPath       string // バイナリの絶対パス
+	BinaryName       string // filepath.Base(BinaryPath)、.exe を含む（trim しない）
+	PackagePath      string // `path` 行 → go install に使う
+	ModulePath       string // `mod` 行フィールド2（モジュールルート）
+	InstalledVersion string // `mod` 行フィールド3
+	GoVersion        string
+}
+
+// UpdateTarget は go install に渡すパスを返す（PackagePath + "@latest"）。
+// フィールドではなくメソッドにすることで PackagePath との不整合を防ぐ。
+func (i GoBinaryInfo) UpdateTarget() string {
+	if i.PackagePath == "" {
+		return ""
+	}
+
+	return i.PackagePath + "@latest"
+}
+
+// ParseGoBinaryInfo は "go version -m <binary>" の出力を解析し、GoBinaryInfo を返します。
+// path 行が存在しない場合は nil と error を返します。
+func ParseGoBinaryInfo(binaryPath, output string) (*GoBinaryInfo, error) {
+	info := &GoBinaryInfo{
+		BinaryPath: binaryPath,
+		BinaryName: filepath.Base(binaryPath),
+	}
+
+	foundPath := false
 	scanner := bufio.NewScanner(strings.NewReader(output))
+
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
-		if strings.HasPrefix(line, "path") {
-			parts := strings.Fields(line)
-			if len(parts) >= 2 {
-				modulePath = parts[1]
-			}
+		fields := strings.Fields(line)
+
+		if len(fields) >= 2 && fields[0] == "path" {
+			info.PackagePath = fields[1]
+			foundPath = true
 		}
 
-		if strings.HasPrefix(line, "mod") {
-			parts := strings.Fields(line)
-			if len(parts) >= 3 {
-				modulePath = parts[1]
-				version = parts[2]
-			}
+		if len(fields) >= 3 && fields[0] == "mod" {
+			info.ModulePath = fields[1]
+			info.InstalledVersion = fields[2]
 		}
 	}
 
-	return
+	if !foundPath {
+		return nil, fmt.Errorf("go version -m の出力に path 行が見つかりませんでした: %s", binaryPath)
+	}
+
+	return info, nil
 }

--- a/internal/updater/go.go
+++ b/internal/updater/go.go
@@ -225,7 +225,7 @@ type GoBinaryInfo struct {
 
 // UpdateTarget は go install に渡すパスを返す（PackagePath + "@latest"）。
 // フィールドではなくメソッドにすることで PackagePath との不整合を防ぐ。
-func (i GoBinaryInfo) UpdateTarget() string {
+func (i *GoBinaryInfo) UpdateTarget() string {
 	if i.PackagePath == "" {
 		return ""
 	}

--- a/internal/updater/go_test.go
+++ b/internal/updater/go_test.go
@@ -198,17 +198,17 @@ func TestListInstalledGoTools(t *testing.T) {
 func TestGoBinaryInfo_UpdateTarget(t *testing.T) {
 	tests := []struct {
 		name     string
-		info     GoBinaryInfo
+		info     *GoBinaryInfo
 		expected string
 	}{
 		{
 			name:     "PackagePathあり",
-			info:     GoBinaryInfo{PackagePath: "github.com/foo/bar"},
+			info:     &GoBinaryInfo{PackagePath: "github.com/foo/bar"},
 			expected: "github.com/foo/bar@latest",
 		},
 		{
 			name:     "PackagePathが空",
-			info:     GoBinaryInfo{PackagePath: ""},
+			info:     &GoBinaryInfo{PackagePath: ""},
 			expected: "",
 		},
 	}

--- a/internal/updater/go_test.go
+++ b/internal/updater/go_test.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
-	"strings"
 	"testing"
 
 	"github.com/scottlz0310/dsx/internal/config"
@@ -196,52 +195,94 @@ func TestListInstalledGoTools(t *testing.T) {
 	})
 }
 
-func TestParseGoVersionOutput(t *testing.T) {
+func TestGoBinaryInfo_UpdateTarget(t *testing.T) {
 	tests := []struct {
-		name            string
-		output          string
-		expectedModule  string
-		expectedVersion string
+		name     string
+		info     GoBinaryInfo
+		expected string
 	}{
 		{
-			name:           "path行のみ",
-			output:         "go version go1.25.6 windows/amd64\npath\tgithub.com/example/tool\n",
-			expectedModule: "github.com/example/tool",
+			name:     "PackagePathあり",
+			info:     GoBinaryInfo{PackagePath: "github.com/foo/bar"},
+			expected: "github.com/foo/bar@latest",
 		},
 		{
-			name:            "mod行を優先",
-			output:          "path\tgithub.com/example/tool\nmod\tgithub.com/example/tool\tv1.2.3\th1:dummy\n",
-			expectedModule:  "github.com/example/tool",
-			expectedVersion: "v1.2.3",
-		},
-		{
-			name:   "該当なし",
-			output: "go version go1.25.6 windows/amd64\n",
-		},
-		{
-			name:           "余分な空白を含む",
-			output:         "   path    github.com/example/tool   \n",
-			expectedModule: "github.com/example/tool",
+			name:     "PackagePathが空",
+			info:     GoBinaryInfo{PackagePath: ""},
+			expected: "",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			modulePath, version := ParseGoVersionOutput(tt.output)
-			assert.Equal(t, tt.expectedModule, modulePath)
-			assert.Equal(t, tt.expectedVersion, version)
+			assert.Equal(t, tt.expected, tt.info.UpdateTarget())
 		})
 	}
+}
 
-	t.Run("複数行のmodとpathが混在してもパースできる", func(t *testing.T) {
-		output := strings.Join([]string{
-			"go version -m dummy",
-			"path github.com/example/tool",
-			"mod github.com/example/tool v9.9.9 h1:dummy",
-		}, "\n")
+func TestParseGoBinaryInfo(t *testing.T) {
+	tests := []struct {
+		name            string
+		binaryPath      string
+		output          string
+		wantPackagePath string
+		wantModulePath  string
+		wantVersion     string
+		wantBinaryName  string
+		wantErr         bool
+	}{
+		{
+			name:            "path行のみ",
+			binaryPath:      "/usr/local/bin/bar",
+			output:          "path github.com/foo/bar\n",
+			wantPackagePath: "github.com/foo/bar",
+			wantBinaryName:  "bar",
+		},
+		{
+			name:            "mod行あり",
+			binaryPath:      "/usr/local/bin/bar",
+			output:          "path github.com/foo/bar\nmod github.com/foo v1.2.3 h1:dummy\n",
+			wantPackagePath: "github.com/foo/bar",
+			wantModulePath:  "github.com/foo",
+			wantVersion:     "v1.2.3",
+			wantBinaryName:  "bar",
+		},
+		{
+			name:       "path行なし",
+			binaryPath: "/usr/local/bin/bar",
+			output:     "mod github.com/foo v1.2.3 h1:dummy\n",
+			wantErr:    true,
+		},
+		{
+			name:       "空出力",
+			binaryPath: "/usr/local/bin/bar",
+			output:     "",
+			wantErr:    true,
+		},
+		{
+			name:       "改行のみ",
+			binaryPath: "/usr/local/bin/bar",
+			output:     "\n\n",
+			wantErr:    true,
+		},
+	}
 
-		modulePath, version := ParseGoVersionOutput(output)
-		assert.Equal(t, "github.com/example/tool", modulePath)
-		assert.Equal(t, "v9.9.9", version)
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseGoBinaryInfo(tt.binaryPath, tt.output)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Nil(t, got)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, got)
+			assert.Equal(t, tt.binaryPath, got.BinaryPath)
+			assert.Equal(t, tt.wantBinaryName, got.BinaryName)
+			assert.Equal(t, tt.wantPackagePath, got.PackagePath)
+			assert.Equal(t, tt.wantModulePath, got.ModulePath)
+			assert.Equal(t, tt.wantVersion, got.InstalledVersion)
+		})
+	}
 }

--- a/internal/updater/go_test.go
+++ b/internal/updater/go_test.go
@@ -211,6 +211,11 @@ func TestGoBinaryInfo_UpdateTarget(t *testing.T) {
 			info:     &GoBinaryInfo{PackagePath: ""},
 			expected: "",
 		},
+		{
+			name:     "nilレシーバ",
+			info:     nil,
+			expected: "",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## 概要

Issue #45 の実装。`ParseGoVersionOutput` が `path` 行と `mod` 行を同一フィールドに混入させるバグを修正し、`GoBinaryInfo` 構造体と `ParseGoBinaryInfo(binaryPath, output string)` に置換。

## 変更内容

- **`GoBinaryInfo` 構造体を定義**（`BinaryPath`/`BinaryName`/`PackagePath`/`ModulePath`/`InstalledVersion`/`GoVersion`）
- **`UpdateTarget()` メソッド**を実装（`PackagePath + "@latest"`）
- **`ParseGoBinaryInfo(binaryPath, output)`** を実装（`path` 行なし・空出力時は `error`）
- **`ParseGoVersionOutput` を削除**（`path`/`mod` 混入バグを根本修正）
- **`TestParseGoVersionOutput` → `TestParseGoBinaryInfo`** に書き換え（table-driven、境界値・エラー系含む）

## テスト

全ケースPASS（path行のみ / mod行あり / path行なし / 空出力 / 改行のみ）

## 受け入れ条件
- [x] `GoBinaryInfo` 型が定義されている
- [x] `UpdateTarget()` メソッドが実装されている
- [x] `ParseGoBinaryInfo(binaryPath, output)` が実装されている
- [x] `ParseGoVersionOutput` が削除されている
- [x] テストがすべてパスする（`task test`）

Closes #45
親 Issue: #44
