### PR TITLE
docs: Issue #45完了記録・CHANGELOG更新

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@
 
 ## [Unreleased]
 
+### Added
+
+- `GoBinaryInfo` 構造体を `internal/updater` に追加（`BinaryPath`・`BinaryName`・`PackagePath`・`ModulePath`・`InstalledVersion`・`GoVersion` の 6 フィールド）
+- `ParseGoBinaryInfo(binaryPath, output string)` を実装し、`go version -m` 出力の `path` 行と `mod` 行を個別フィールドに分離して解析
+- `UpdateTarget()` メソッドをポインタレシーバで実装（nil ガード付き）
+
+### Changed
+
+- `ParseGoVersionOutput` を廃止。`path` 行と `mod` 行を同一フィールドに混在させるバグを根本解消
+
 ## [v0.2.5] - 2026-04-07
 
 ### Fixed

--- a/tasks.md
+++ b/tasks.md
@@ -33,6 +33,17 @@
 
 ---
 
+## Issue #45: GoBinaryInfo構造体定義・ParseGoBinaryInfo実装（完了）
+
+- [x] `GoBinaryInfo` 構造体定義（6フィールド）
+- [x] `ParseGoBinaryInfo(binaryPath, output)` 実装（path行・mod行の分離、scanner.Err()チェック）
+- [x] `UpdateTarget()` メソッド実装（ポインタレシーバ、nilガード付き）
+- [x] `ParseGoVersionOutput` 削除
+- [x] テスト追加（table-driven、境界値・nilガード含む）
+- [x] PR #49 マージ → main
+
+---
+
 ## Backlog / 改善候補
 
 ### `AutoStash` オプションの修正（設定が機能していないバグ）


### PR DESCRIPTION
## 概要

PR #49 マージ後のドキュメント更新。

- \CHANGELOG.md\: GoBinaryInfo構造体・ParseGoBinaryInfo実装・ParseGoVersionOutput廃止を [Unreleased] に記録
- \	asks.md\: Issue #45 完了チェックを追記