### PR TITLE
[T2] DiscoverGoBinaries / DiscoverGoBinariesInDir 実装 (#46)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 - `GoBinaryInfo` 構造体を `internal/updater` に追加（`BinaryPath`・`BinaryName`・`PackagePath`・`ModulePath`・`InstalledVersion`・`GoVersion` の 6 フィールド）
 - `ParseGoBinaryInfo(binaryPath, output string)` を実装し、`go version -m` 出力の `path` 行と `mod` 行を個別フィールドに分離して解析
 - `UpdateTarget()` メソッドをポインタレシーバで実装（nil ガード付き）
+- `DiscoverResult` / `SkippedBinary` 型を `internal/updater` に追加
+- `DiscoverGoBinariesInDir(ctx, binDir)` を実装（指定ディレクトリ内の Go バイナリをスキャンし、`go version -m` で情報を収集）
+- `DiscoverGoBinaries(ctx)` を実装（`GOBIN` → `GOPATH/bin` → `~/go/bin` の順で自動解決してスキャン）
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@
 
 ## [Unreleased]
 
+### Added
+
+- `GoBinaryInfo` 構造体を `internal/updater` に追加（`BinaryPath`・`BinaryName`・`PackagePath`・`ModulePath`・`InstalledVersion`・`GoVersion` の 6 フィールド）
+- `ParseGoBinaryInfo(binaryPath, output string)` を実装し、`go version -m` 出力の `path` 行と `mod` 行を個別フィールドに分離して解析
+- `UpdateTarget()` メソッドをポインタレシーバで実装（nil ガード付き）
+
+### Changed
+
+- `ParseGoVersionOutput` を廃止。`path` 行と `mod` 行を同一フィールドに混在させるバグを根本解消
+
 ## [v0.2.5] - 2026-04-07
 
 ### Fixed

--- a/internal/updater/command_locale.go
+++ b/internal/updater/command_locale.go
@@ -11,7 +11,7 @@ import (
 
 // runCommandOutputWithLocaleC は LANG/LC_ALL を C に固定してコマンド出力を取得します。
 func runCommandOutputWithLocaleC(ctx context.Context, command string, args []string, errFormat string) ([]byte, error) {
-	cmd := exec.CommandContext(ctx, command, args...)
+	cmd := exec.CommandContext(ctx, command, args...) //nolint:gosec // G702: command と args はすべて内部の固定値から呼ばれており外部入力ではない
 
 	cmd.Env = append(os.Environ(), "LANG=C", "LC_ALL=C")
 

--- a/internal/updater/command_locale.go
+++ b/internal/updater/command_locale.go
@@ -11,7 +11,7 @@ import (
 
 // runCommandOutputWithLocaleC は LANG/LC_ALL を C に固定してコマンド出力を取得します。
 func runCommandOutputWithLocaleC(ctx context.Context, command string, args []string, errFormat string) ([]byte, error) {
-	cmd := exec.CommandContext(ctx, command, args...) //nolint:gosec // G702: command と args はすべて内部の固定値から呼ばれており外部入力ではない
+	cmd := exec.CommandContext(ctx, command, args...) //nolint:gosec // G702: 呼び出し側では command は "go"/"git" 等の固定値のみを渡す設計
 
 	cmd.Env = append(os.Environ(), "LANG=C", "LC_ALL=C")
 

--- a/internal/updater/go.go
+++ b/internal/updater/go.go
@@ -234,6 +234,101 @@ func (i *GoBinaryInfo) UpdateTarget() string {
 	return i.PackagePath + "@latest"
 }
 
+// DiscoverResult は DiscoverGoBinaries / DiscoverGoBinariesInDir の結果を保持します。
+type DiscoverResult struct {
+	Detected []GoBinaryInfo
+	Skipped  []SkippedBinary
+}
+
+// SkippedBinary はスキャン中にスキップされたバイナリの情報を保持します。
+type SkippedBinary struct {
+	Name   string
+	Reason string // "Go モジュール情報なし" / "バックアップファイル"
+}
+
+// runGoVersionM は "go version -m <binaryPath>" を実行して出力を返します。
+func runGoVersionM(ctx context.Context, binaryPath string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, "go", "version", "-m", binaryPath)
+	return cmd.Output()
+}
+
+// discoverInDir は binDir 内のバイナリをスキャンし、DiscoverResult を返します。
+// runCmd はテスト時に fakeRunCmd を注入できる関数パラメータです。
+func discoverInDir(ctx context.Context, binDir string,
+	runCmd func(context.Context, string) ([]byte, error)) (*DiscoverResult, error) {
+	entries, err := os.ReadDir(binDir)
+	if err != nil {
+		return nil, fmt.Errorf("%s の読み取りに失敗: %w", binDir, err)
+	}
+
+	result := &DiscoverResult{}
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+
+		name := entry.Name()
+
+		// *~ / *.exe~ パターン（バックアップファイル）を除外
+		if strings.HasSuffix(name, "~") {
+			result.Skipped = append(result.Skipped, SkippedBinary{
+				Name:   name,
+				Reason: "バックアップファイル",
+			})
+			continue
+		}
+
+		fullPath := filepath.Join(binDir, name)
+
+		output, err := runCmd(ctx, fullPath)
+		if err != nil {
+			result.Skipped = append(result.Skipped, SkippedBinary{
+				Name:   name,
+				Reason: "Go モジュール情報なし",
+			})
+			continue
+		}
+
+		info, err := ParseGoBinaryInfo(fullPath, string(output))
+		if err != nil {
+			result.Skipped = append(result.Skipped, SkippedBinary{
+				Name:   name,
+				Reason: "Go モジュール情報なし",
+			})
+			continue
+		}
+
+		result.Detected = append(result.Detected, *info)
+	}
+
+	return result, nil
+}
+
+// DiscoverGoBinariesInDir は指定ディレクトリ内の Go バイナリ情報を収集します。
+func DiscoverGoBinariesInDir(ctx context.Context, binDir string) (*DiscoverResult, error) {
+	return discoverInDir(ctx, binDir, runGoVersionM)
+}
+
+// DiscoverGoBinaries は $GOBIN → $GOPATH/bin → ~/go/bin の順でパスを解決し、
+// Go バイナリ情報を収集します。
+func DiscoverGoBinaries(ctx context.Context) (*DiscoverResult, error) {
+	binDir := os.Getenv("GOBIN")
+	if binDir == "" {
+		gopath := os.Getenv("GOPATH")
+		if gopath == "" {
+			home, err := os.UserHomeDir()
+			if err != nil {
+				return nil, fmt.Errorf("ホームディレクトリの取得に失敗: %w", err)
+			}
+			gopath = filepath.Join(home, "go")
+		}
+		binDir = filepath.Join(gopath, "bin")
+	}
+
+	return DiscoverGoBinariesInDir(ctx, binDir)
+}
+
 // ParseGoBinaryInfo は "go version -m <binary>" の出力を解析し、GoBinaryInfo を返します。
 // path 行が存在しない場合は nil と error を返します。
 func ParseGoBinaryInfo(binaryPath, output string) (*GoBinaryInfo, error) {

--- a/internal/updater/go.go
+++ b/internal/updater/go.go
@@ -3,6 +3,7 @@ package updater
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -283,6 +284,11 @@ func discoverInDir(ctx context.Context, binDir string,
 
 		output, err := runCmd(ctx, fullPath)
 		if err != nil {
+			// コンテキストキャンセル・期限切れの場合はスキャンを中断する
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				return nil, err
+			}
+
 			result.Skipped = append(result.Skipped, SkippedBinary{
 				Name:   name,
 				Reason: "Go モジュール情報なし",
@@ -329,8 +335,24 @@ func DiscoverGoBinaries(ctx context.Context) (*DiscoverResult, error) {
 
 		// GOPATH は OS によってはパスリスト（Unix では ":" 区切り、Windows では ";" 区切り）に
 		// なり得るため、filepath.SplitList で先頭エントリを取得してから "bin" を連結する。
+		// 先頭エントリが空の場合（区切り文字のみの GOPATH 等）は ~/go にフォールバックする。
 		gopathEntries := filepath.SplitList(gopath)
-		binDir = filepath.Join(gopathEntries[0], "bin")
+		firstEntry := ""
+
+		if len(gopathEntries) > 0 {
+			firstEntry = gopathEntries[0]
+		}
+
+		if firstEntry == "" {
+			home, err := os.UserHomeDir()
+			if err != nil {
+				return nil, fmt.Errorf("ホームディレクトリの取得に失敗: %w", err)
+			}
+
+			firstEntry = filepath.Join(home, "go")
+		}
+
+		binDir = filepath.Join(firstEntry, "bin")
 	}
 
 	return DiscoverGoBinariesInDir(ctx, binDir)

--- a/internal/updater/go.go
+++ b/internal/updater/go.go
@@ -248,8 +248,7 @@ type SkippedBinary struct {
 
 // runGoVersionM は "go version -m <binaryPath>" を実行して出力を返します。
 func runGoVersionM(ctx context.Context, binaryPath string) ([]byte, error) {
-	cmd := exec.CommandContext(ctx, "go", "version", "-m", binaryPath) //nolint:gosec // binaryPath は os.ReadDir 由来のシステムパスであり外部入力ではない
-	return cmd.Output()
+	return runCommandOutputWithLocaleC(ctx, "go", []string{"version", "-m", binaryPath}, "go version -m の実行に失敗: %w")
 }
 
 // discoverInDir は binDir 内のバイナリをスキャンし、DiscoverResult を返します。
@@ -328,7 +327,10 @@ func DiscoverGoBinaries(ctx context.Context) (*DiscoverResult, error) {
 			gopath = filepath.Join(home, "go")
 		}
 
-		binDir = filepath.Join(gopath, "bin")
+		// GOPATH は OS によってはパスリスト（Unix では ":" 区切り、Windows では ";" 区切り）に
+		// なり得るため、filepath.SplitList で先頭エントリを取得してから "bin" を連結する。
+		gopathEntries := filepath.SplitList(gopath)
+		binDir = filepath.Join(gopathEntries[0], "bin")
 	}
 
 	return DiscoverGoBinariesInDir(ctx, binDir)

--- a/internal/updater/go.go
+++ b/internal/updater/go.go
@@ -248,7 +248,7 @@ type SkippedBinary struct {
 
 // runGoVersionM は "go version -m <binaryPath>" を実行して出力を返します。
 func runGoVersionM(ctx context.Context, binaryPath string) ([]byte, error) {
-	cmd := exec.CommandContext(ctx, "go", "version", "-m", binaryPath)
+	cmd := exec.CommandContext(ctx, "go", "version", "-m", binaryPath) //nolint:gosec // binaryPath は os.ReadDir 由来のシステムパスであり外部入力ではない
 	return cmd.Output()
 }
 
@@ -276,6 +276,7 @@ func discoverInDir(ctx context.Context, binDir string,
 				Name:   name,
 				Reason: "バックアップファイル",
 			})
+
 			continue
 		}
 
@@ -287,6 +288,7 @@ func discoverInDir(ctx context.Context, binDir string,
 				Name:   name,
 				Reason: "Go モジュール情報なし",
 			})
+
 			continue
 		}
 
@@ -296,6 +298,7 @@ func discoverInDir(ctx context.Context, binDir string,
 				Name:   name,
 				Reason: "Go モジュール情報なし",
 			})
+
 			continue
 		}
 
@@ -321,8 +324,10 @@ func DiscoverGoBinaries(ctx context.Context) (*DiscoverResult, error) {
 			if err != nil {
 				return nil, fmt.Errorf("ホームディレクトリの取得に失敗: %w", err)
 			}
+
 			gopath = filepath.Join(home, "go")
 		}
+
 		binDir = filepath.Join(gopath, "bin")
 	}
 

--- a/internal/updater/go_test.go
+++ b/internal/updater/go_test.go
@@ -438,16 +438,18 @@ func TestDiscoverGoBinariesInDir_MissingDir(t *testing.T) {
 func TestDiscoverGoBinaries_UsesGOBIN(t *testing.T) {
 	// t.Setenv は t.Parallel() と併用不可
 	dir := t.TempDir()
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "tool"), []byte{}, 0o644))
+	// *~ ファイルはバックアップファイルとして go version -m を起動せずに Skipped 処理されるため、
+	// 外部プロセスを発生させずに GOBIN 優先を検証できる
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "tool~"), []byte{}, 0o644))
 	t.Setenv("GOBIN", dir)
 	t.Setenv("GOPATH", "")
 
-	// go version -m は実際には呼ばれるが、テスト環境ではバイナリが Go 製でないため Skipped に入る
 	result, err := DiscoverGoBinaries(context.Background())
 	require.NoError(t, err)
 	require.NotNil(t, result)
-	// Detected + Skipped の合計が 1 (ファイル "tool" 1件のみ)
-	assert.Equal(t, 1, len(result.Detected)+len(result.Skipped))
+	assert.Len(t, result.Skipped, 1)
+	assert.Equal(t, "tool~", result.Skipped[0].Name)
+	assert.Equal(t, "バックアップファイル", result.Skipped[0].Reason)
 }
 
 func TestDiscoverInDir_ContextCanceled(t *testing.T) {

--- a/internal/updater/go_test.go
+++ b/internal/updater/go_test.go
@@ -449,3 +449,21 @@ func TestDiscoverGoBinaries_UsesGOBIN(t *testing.T) {
 	// Detected + Skipped の合計が 1 (ファイル "tool" 1件のみ)
 	assert.Equal(t, 1, len(result.Detected)+len(result.Skipped))
 }
+
+func TestDiscoverInDir_ContextCanceled(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "tool"), []byte{}, 0o644))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // 即座にキャンセル
+
+	fakeRunCmd := func(c context.Context, _ string) ([]byte, error) {
+		return nil, c.Err()
+	}
+
+	_, err := discoverInDir(ctx, dir, fakeRunCmd)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.Canceled)
+}

--- a/internal/updater/go_test.go
+++ b/internal/updater/go_test.go
@@ -401,10 +401,12 @@ func TestDiscoverGoBinariesInDir(t *testing.T) {
 				assert.Empty(t, result.Detected)
 			} else {
 				require.Len(t, result.Detected, len(tt.wantDetected))
+
 				names := make([]string, len(result.Detected))
 				for i, d := range result.Detected {
 					names[i] = d.BinaryName
 				}
+
 				assert.ElementsMatch(t, tt.wantDetected, names)
 			}
 
@@ -413,10 +415,12 @@ func TestDiscoverGoBinariesInDir(t *testing.T) {
 				assert.Empty(t, result.Skipped)
 			} else {
 				require.Len(t, result.Skipped, len(tt.wantSkipped))
+
 				names := make([]string, len(result.Skipped))
 				for i, s := range result.Skipped {
 					names[i] = s.Name
 				}
+
 				assert.ElementsMatch(t, tt.wantSkipped, names)
 			}
 		})

--- a/internal/updater/go_test.go
+++ b/internal/updater/go_test.go
@@ -2,6 +2,7 @@ package updater
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"sort"
@@ -290,4 +291,157 @@ func TestParseGoBinaryInfo(t *testing.T) {
 			assert.Equal(t, tt.wantVersion, got.InstalledVersion)
 		})
 	}
+}
+
+func TestDiscoverGoBinariesInDir(t *testing.T) {
+	t.Parallel()
+
+	fakeOutput := "path github.com/foo/mytool\nmod github.com/foo v1.2.3 h1:dummy\n"
+
+	tests := []struct {
+		name         string
+		setup        func(t *testing.T, dir string)
+		fakeRunCmd   func(ctx context.Context, path string) ([]byte, error)
+		wantDetected []string // BinaryName の一覧
+		wantSkipped  []string // SkippedBinary.Name の一覧
+	}{
+		{
+			name: "バックアップファイル（*.exe~）はSkippedに入る",
+			setup: func(t *testing.T, dir string) {
+				t.Helper()
+				require.NoError(t, os.WriteFile(filepath.Join(dir, "tool.exe~"), []byte{}, 0o644))
+			},
+			fakeRunCmd: func(_ context.Context, _ string) ([]byte, error) {
+				return nil, errors.New("呼ばれてはいけない")
+			},
+			wantDetected: nil,
+			wantSkipped:  []string{"tool.exe~"},
+		},
+		{
+			name: "ディレクトリは除外される（DetectedにもSkippedにも入らない）",
+			setup: func(t *testing.T, dir string) {
+				t.Helper()
+				require.NoError(t, os.Mkdir(filepath.Join(dir, "subdir"), 0o755))
+			},
+			fakeRunCmd: func(_ context.Context, _ string) ([]byte, error) {
+				return nil, errors.New("呼ばれてはいけない")
+			},
+			wantDetected: nil,
+			wantSkipped:  nil,
+		},
+		{
+			name: "go version -m 失敗バイナリはSkippedに入る",
+			setup: func(t *testing.T, dir string) {
+				t.Helper()
+				require.NoError(t, os.WriteFile(filepath.Join(dir, "notgobin"), []byte{}, 0o644))
+			},
+			fakeRunCmd: func(_ context.Context, _ string) ([]byte, error) {
+				return nil, errors.New("exit status 1")
+			},
+			wantDetected: nil,
+			wantSkipped:  []string{"notgobin"},
+		},
+		{
+			name: "path行なしバイナリはSkippedに入る",
+			setup: func(t *testing.T, dir string) {
+				t.Helper()
+				require.NoError(t, os.WriteFile(filepath.Join(dir, "nopath"), []byte{}, 0o644))
+			},
+			fakeRunCmd: func(_ context.Context, _ string) ([]byte, error) {
+				return []byte("mod github.com/foo v1.0.0 h1:dummy\n"), nil
+			},
+			wantDetected: nil,
+			wantSkipped:  []string{"nopath"},
+		},
+		{
+			name: "正常バイナリはDetectedに入る",
+			setup: func(t *testing.T, dir string) {
+				t.Helper()
+				require.NoError(t, os.WriteFile(filepath.Join(dir, "mytool"), []byte{}, 0o644))
+			},
+			fakeRunCmd: func(_ context.Context, _ string) ([]byte, error) {
+				return []byte(fakeOutput), nil
+			},
+			wantDetected: []string{"mytool"},
+			wantSkipped:  nil,
+		},
+		{
+			name: "バックアップ・失敗・正常が混在する場合",
+			setup: func(t *testing.T, dir string) {
+				t.Helper()
+				require.NoError(t, os.WriteFile(filepath.Join(dir, "backup~"), []byte{}, 0o644))
+				require.NoError(t, os.WriteFile(filepath.Join(dir, "broken"), []byte{}, 0o644))
+				require.NoError(t, os.WriteFile(filepath.Join(dir, "good"), []byte{}, 0o644))
+				require.NoError(t, os.Mkdir(filepath.Join(dir, "dir"), 0o755))
+			},
+			fakeRunCmd: func(_ context.Context, path string) ([]byte, error) {
+				if filepath.Base(path) == "broken" {
+					return nil, errors.New("not a go binary")
+				}
+				return []byte("path github.com/foo/" + filepath.Base(path) + "\nmod github.com/foo v1.0.0 h1:dummy\n"), nil
+			},
+			wantDetected: []string{"good"},
+			wantSkipped:  []string{"backup~", "broken"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			dir := t.TempDir()
+			tt.setup(t, dir)
+
+			result, err := discoverInDir(context.Background(), dir, tt.fakeRunCmd)
+			require.NoError(t, err)
+			require.NotNil(t, result)
+
+			// Detected の BinaryName 一覧を検証
+			if tt.wantDetected == nil {
+				assert.Empty(t, result.Detected)
+			} else {
+				require.Len(t, result.Detected, len(tt.wantDetected))
+				names := make([]string, len(result.Detected))
+				for i, d := range result.Detected {
+					names[i] = d.BinaryName
+				}
+				assert.ElementsMatch(t, tt.wantDetected, names)
+			}
+
+			// Skipped の Name 一覧を検証
+			if tt.wantSkipped == nil {
+				assert.Empty(t, result.Skipped)
+			} else {
+				require.Len(t, result.Skipped, len(tt.wantSkipped))
+				names := make([]string, len(result.Skipped))
+				for i, s := range result.Skipped {
+					names[i] = s.Name
+				}
+				assert.ElementsMatch(t, tt.wantSkipped, names)
+			}
+		})
+	}
+}
+
+func TestDiscoverGoBinariesInDir_MissingDir(t *testing.T) {
+	t.Parallel()
+
+	_, err := DiscoverGoBinariesInDir(context.Background(), filepath.Join(t.TempDir(), "missing"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "読み取りに失敗")
+}
+
+func TestDiscoverGoBinaries_UsesGOBIN(t *testing.T) {
+	// t.Setenv は t.Parallel() と併用不可
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "tool"), []byte{}, 0o644))
+	t.Setenv("GOBIN", dir)
+	t.Setenv("GOPATH", "")
+
+	// go version -m は実際には呼ばれるが、テスト環境ではバイナリが Go 製でないため Skipped に入る
+	result, err := DiscoverGoBinaries(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	// Detected + Skipped の合計が 1 (ファイル "tool" 1件のみ)
+	assert.Equal(t, 1, len(result.Detected)+len(result.Skipped))
 }

--- a/tasks.md
+++ b/tasks.md
@@ -33,6 +33,17 @@
 
 ---
 
+## Issue #45: GoBinaryInfo構造体定義・ParseGoBinaryInfo実装（完了）
+
+- [x] `GoBinaryInfo` 構造体定義（6フィールド）
+- [x] `ParseGoBinaryInfo(binaryPath, output)` 実装（path行・mod行の分離、scanner.Err()チェック）
+- [x] `UpdateTarget()` メソッド実装（ポインタレシーバ、nilガード付き）
+- [x] `ParseGoVersionOutput` 削除
+- [x] テスト追加（table-driven、境界値・nilガード含む）
+- [x] PR #49 マージ → main
+
+---
+
 ## Backlog / 改善候補
 
 ### `AutoStash` オプションの修正（設定が機能していないバグ）


### PR DESCRIPTION
## 概要

Issue #46 の実装。`GOBIN` / `GOPATH/bin` をスキャンして Go バイナリ情報を収集する関数群を追加します。

## 変更内容

### 追加した型

- `DiscoverResult` — `Detected []GoBinaryInfo` と `Skipped []SkippedBinary` を保持
- `SkippedBinary` — スキップされたバイナリの名前と理由

### 追加した関数

- `runGoVersionM` — `go version -m <path>` を実行する内部ヘルパー
- `discoverInDir` — fakeRunCmd を注入できる unexported 関数（テスト容易性確保）
- `DiscoverGoBinariesInDir` — 指定ディレクトリをスキャンする公開 API
- `DiscoverGoBinaries` — `GOBIN → GOPATH/bin → ~/go/bin` を自動解決する公開 API

### 処理フロー

1. `os.ReadDir` でファイル一覧取得（ディレクトリは除外）
2. `*~` / `*.exe~` パターンをバックアップファイルとしてスキップ
3. `go version -m <binary>` を実行 → 失敗時は "Go モジュール情報なし" でスキップ
4. `path` 行なし → "Go モジュール情報なし" でスキップ
5. 成功 → `GoBinaryInfo` に追加

## テスト

`TestDiscoverGoBinariesInDir` (table-driven / t.Parallel / fakeRunCmd 注入):

| ケース | 検証内容 |
|--------|---------|
| バックアップファイル (`*.exe~`) | Skipped に入る |
| ディレクトリ | Detected にも Skipped にも入らない |
| `go version -m` 失敗 | Skipped に入る |
| `path` 行なし | Skipped に入る |
| 正常バイナリ | Detected に入る |
| 混在ケース | それぞれ正しく分類される |

加えて `TestDiscoverGoBinariesInDir_MissingDir` と `TestDiscoverGoBinaries_UsesGOBIN` も追加。

## 受け入れ条件

- [x] `DiscoverGoBinaries(ctx)` が実装されている
- [x] `DiscoverGoBinariesInDir(ctx, binDir)` が実装されている
- [x] `discoverInDir` に fakeRunCmd を渡すテストが通る
- [x] `task test` がパス（lint / test 全パス確認済み）

## 関連

- 親 Issue: #44
- 依存: #45（T1 完了済み）

Closes #46
