### PR TITLE
feat: dsx sys discover コマンドを実装（#47）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - `DiscoverResult` / `SkippedBinary` 型を `internal/updater` に追加
 - `DiscoverGoBinariesInDir(ctx, binDir)` を実装（指定ディレクトリ内の Go バイナリをスキャンし、`go version -m` で情報を収集）
 - `DiscoverGoBinaries(ctx)` を実装（`GOBIN` → `GOPATH/bin` → `~/go/bin` の順で自動解決してスキャン）
+- `dsx sys discover` コマンドを追加（`GOBIN`/`GOPATH/bin`/`~/go/bin` 内の Go バイナリを検出し、モジュール情報と共に一覧表示）
 
 ### Changed
 

--- a/cmd/dsx/sys_discover.go
+++ b/cmd/dsx/sys_discover.go
@@ -39,7 +39,12 @@ func runSysDiscover(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
+	baseCtx := cmd.Context()
+	if baseCtx == nil {
+		baseCtx = context.Background()
+	}
+
+	ctx, cancel := context.WithCancel(baseCtx)
 	defer cancel()
 
 	sigCh := make(chan os.Signal, 1)
@@ -68,7 +73,6 @@ func resolveDiscoverManagers(manager string) ([]string, error) {
 	}
 
 	if !isSupportedDiscoverManager(manager) {
-		fmt.Fprintf(os.Stderr, "❌ 未対応のマネージャ: %s\n", manager)
 		return nil, fmt.Errorf("未対応のマネージャ: %s", manager)
 	}
 
@@ -111,26 +115,26 @@ func discoverGoManager(ctx context.Context) error {
 // printGoDiscoverResult は DiscoverResult を指定フォーマットで標準出力に表示します。
 func printGoDiscoverResult(result *updater.DiscoverResult) {
 	if len(result.Detected) == 0 {
-		fmt.Println("Go ツールは検出されませんでした。")
+		fmt.Println("[go] 検出されたバイナリはありませんでした。")
 	} else {
-		fmt.Println("検出された Go ツール:")
+		fmt.Println("[go] 検出されたバイナリ:")
 
 		for _, info := range result.Detected {
 			target := info.UpdateTarget()
 			if info.InstalledVersion != "" {
-				fmt.Printf("  - %-20s %s (インストール済み: %s)\n", info.BinaryName, target, info.InstalledVersion)
+				fmt.Printf("  %-20s %s (インストール済み: %s)\n", info.BinaryName, target, info.InstalledVersion)
 			} else {
-				fmt.Printf("  - %-20s %s\n", info.BinaryName, target)
+				fmt.Printf("  %-20s %s\n", info.BinaryName, target)
 			}
 		}
 	}
 
 	if len(result.Skipped) > 0 {
 		fmt.Println()
-		fmt.Println("スキップ:")
+		fmt.Println("[go] スキップ:")
 
 		for _, s := range result.Skipped {
-			fmt.Printf("  - %-20s %s\n", s.Name, s.Reason)
+			fmt.Printf("  %-20s %s\n", s.Name, s.Reason)
 		}
 	}
 

--- a/cmd/dsx/sys_discover.go
+++ b/cmd/dsx/sys_discover.go
@@ -136,7 +136,7 @@ func printGoDiscoverResult(result *updater.DiscoverResult) {
 		fmt.Println("[go] スキップ:")
 
 		for _, s := range result.Skipped {
-			fmt.Printf("  %-20s %s\n", s.Name, s.Reason)
+			fmt.Printf("  %-20s 理由: %s\n", s.Name, s.Reason)
 		}
 	}
 

--- a/cmd/dsx/sys_discover.go
+++ b/cmd/dsx/sys_discover.go
@@ -2,9 +2,11 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/signal"
+	"strings"
 
 	"github.com/scottlz0310/dsx/internal/updater"
 	"github.com/spf13/cobra"
@@ -44,17 +46,8 @@ func runSysDiscover(cmd *cobra.Command, args []string) error {
 		baseCtx = context.Background()
 	}
 
-	ctx, cancel := context.WithCancel(baseCtx)
-	defer cancel()
-
-	sigCh := make(chan os.Signal, 1)
-	signal.Notify(sigCh, os.Interrupt)
-
-	go func() {
-		<-sigCh
-		fmt.Println("\n⚠️  中断シグナルを受信しました。処理を終了します...")
-		cancel()
-	}()
+	ctx, stop := signal.NotifyContext(baseCtx, os.Interrupt)
+	defer stop()
 
 	for _, m := range managers {
 		if err := discoverManager(ctx, m); err != nil {
@@ -68,6 +61,7 @@ func runSysDiscover(cmd *cobra.Command, args []string) error {
 // resolveDiscoverManagers は --manager フラグを解決し、対象マネージャ一覧を返します。
 // 指定がなければ全対応マネージャを返します。未対応名を指定した場合はエラーを返します。
 func resolveDiscoverManagers(manager string) ([]string, error) {
+	manager = strings.TrimSpace(manager)
 	if manager == "" {
 		return supportedDiscoverManagers, nil
 	}
@@ -104,6 +98,14 @@ func discoverManager(ctx context.Context, manager string) error {
 func discoverGoManager(ctx context.Context) error {
 	result, err := updater.DiscoverGoBinaries(ctx)
 	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			return fmt.Errorf("処理が中断されました")
+		}
+
+		if errors.Is(err, context.DeadlineExceeded) {
+			return fmt.Errorf("処理がタイムアウトしました")
+		}
+
 		return fmt.Errorf("go バイナリのスキャンに失敗: %w", err)
 	}
 

--- a/cmd/dsx/sys_discover.go
+++ b/cmd/dsx/sys_discover.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+
+	"github.com/scottlz0310/dsx/internal/updater"
+	"github.com/spf13/cobra"
+)
+
+var sysDiscoverManager string
+
+// supportedDiscoverManagers は discover コマンドで対応しているマネージャの一覧です。
+var supportedDiscoverManagers = []string{"go"}
+
+// sysDiscoverCmd はインストール済みツールを検出するコマンドです。
+var sysDiscoverCmd = &cobra.Command{
+	Use:   "discover",
+	Short: "インストール済みのツールを検出します",
+	Long: `$GOBIN/$GOPATH/bin にインストールされた Go ツールをスキャンし、
+go.targets に追加可能な候補を表示します。
+
+例:
+  dsx sys discover              # 全対応マネージャをスキャン
+  dsx sys discover --manager go # Go バイナリのみスキャン`,
+	RunE: runSysDiscover,
+}
+
+func init() {
+	sysCmd.AddCommand(sysDiscoverCmd)
+	sysDiscoverCmd.Flags().StringVar(&sysDiscoverManager, "manager", "", "スキャン対象のマネージャ（例: go）")
+}
+
+func runSysDiscover(cmd *cobra.Command, args []string) error {
+	managers, err := resolveDiscoverManagers(sysDiscoverManager)
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt)
+
+	go func() {
+		<-sigCh
+		fmt.Println("\n⚠️  中断シグナルを受信しました。処理を終了します...")
+		cancel()
+	}()
+
+	for _, m := range managers {
+		if err := discoverManager(ctx, m); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// resolveDiscoverManagers は --manager フラグを解決し、対象マネージャ一覧を返します。
+// 指定がなければ全対応マネージャを返します。未対応名を指定した場合はエラーを返します。
+func resolveDiscoverManagers(manager string) ([]string, error) {
+	if manager == "" {
+		return supportedDiscoverManagers, nil
+	}
+
+	if !isSupportedDiscoverManager(manager) {
+		fmt.Fprintf(os.Stderr, "❌ 未対応のマネージャ: %s\n", manager)
+		return nil, fmt.Errorf("未対応のマネージャ: %s", manager)
+	}
+
+	return []string{manager}, nil
+}
+
+// isSupportedDiscoverManager は指定されたマネージャ名が discover で対応しているかを返します。
+func isSupportedDiscoverManager(name string) bool {
+	for _, m := range supportedDiscoverManagers {
+		if m == name {
+			return true
+		}
+	}
+
+	return false
+}
+
+// discoverManager は指定マネージャのスキャンを実行します。
+func discoverManager(ctx context.Context, manager string) error {
+	switch manager {
+	case "go":
+		return discoverGoManager(ctx)
+	default:
+		return fmt.Errorf("未対応のマネージャ: %s", manager)
+	}
+}
+
+// discoverGoManager は Go バイナリをスキャンして結果を表示します。
+func discoverGoManager(ctx context.Context) error {
+	result, err := updater.DiscoverGoBinaries(ctx)
+	if err != nil {
+		return fmt.Errorf("go バイナリのスキャンに失敗: %w", err)
+	}
+
+	printGoDiscoverResult(result)
+
+	return nil
+}
+
+// printGoDiscoverResult は DiscoverResult を指定フォーマットで標準出力に表示します。
+func printGoDiscoverResult(result *updater.DiscoverResult) {
+	if len(result.Detected) == 0 {
+		fmt.Println("Go ツールは検出されませんでした。")
+	} else {
+		fmt.Println("検出された Go ツール:")
+
+		for _, info := range result.Detected {
+			target := info.UpdateTarget()
+			if info.InstalledVersion != "" {
+				fmt.Printf("  - %-20s %s (インストール済み: %s)\n", info.BinaryName, target, info.InstalledVersion)
+			} else {
+				fmt.Printf("  - %-20s %s\n", info.BinaryName, target)
+			}
+		}
+	}
+
+	if len(result.Skipped) > 0 {
+		fmt.Println()
+		fmt.Println("スキップ:")
+
+		for _, s := range result.Skipped {
+			fmt.Printf("  - %-20s %s\n", s.Name, s.Reason)
+		}
+	}
+
+	fmt.Println()
+	fmt.Println("💡 go.targets に追加するには設定ファイルを編集してください。")
+}

--- a/cmd/dsx/sys_discover_test.go
+++ b/cmd/dsx/sys_discover_test.go
@@ -1,0 +1,309 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/scottlz0310/dsx/internal/updater"
+)
+
+func TestIsSupportedDiscoverManager(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{
+			name:  "go は対応している",
+			input: "go",
+			want:  true,
+		},
+		{
+			name:  "apt は未対応",
+			input: "apt",
+			want:  false,
+		},
+		{
+			name:  "空文字列は未対応",
+			input: "",
+			want:  false,
+		},
+		{
+			name:  "大文字 GO は未対応（大文字小文字区別）",
+			input: "GO",
+			want:  false,
+		},
+		{
+			name:  "brew は未対応",
+			input: "brew",
+			want:  false,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := isSupportedDiscoverManager(tc.input)
+			if got != tc.want {
+				t.Fatalf("isSupportedDiscoverManager(%q) = %v, want %v", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestResolveDiscoverManagers(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		manager string
+		want    []string
+		wantErr bool
+	}{
+		{
+			name:    "空文字列は全対応マネージャを返す",
+			manager: "",
+			want:    supportedDiscoverManagers,
+			wantErr: false,
+		},
+		{
+			name:    "go を指定すると go のみ返す",
+			manager: "go",
+			want:    []string{"go"},
+			wantErr: false,
+		},
+		{
+			name:    "未対応マネージャはエラー",
+			manager: "apt",
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name:    "未知の文字列はエラー",
+			manager: "invalid",
+			want:    nil,
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := resolveDiscoverManagers(tc.manager)
+
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("エラーを期待したが nil が返った")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("予期しないエラー: %v", err)
+			}
+
+			if len(got) != len(tc.want) {
+				t.Fatalf("resolveDiscoverManagers(%q) len = %d, want %d", tc.manager, len(got), len(tc.want))
+			}
+
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Fatalf("resolveDiscoverManagers(%q)[%d] = %q, want %q", tc.manager, i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestPrintGoDiscoverResult_NoneDetected(t *testing.T) {
+	result := &updater.DiscoverResult{}
+	out := captureStdout(t, func() {
+		printGoDiscoverResult(result)
+	})
+
+	if !strings.Contains(out, "検出されませんでした") {
+		t.Fatalf("出力に「検出されませんでした」が含まれていない: %q", out)
+	}
+}
+
+func TestPrintGoDiscoverResult_WithDetected(t *testing.T) {
+	result := &updater.DiscoverResult{
+		Detected: []updater.GoBinaryInfo{
+			{
+				BinaryName:       "gopls",
+				PackagePath:      "golang.org/x/tools/gopls",
+				InstalledVersion: "v0.17.1",
+			},
+			{
+				BinaryName:  "dlv",
+				PackagePath: "github.com/go-delve/delve/cmd/dlv",
+				// InstalledVersion 未設定
+			},
+		},
+	}
+
+	out := captureStdout(t, func() {
+		printGoDiscoverResult(result)
+	})
+
+	if !strings.Contains(out, "検出された Go ツール:") {
+		t.Fatalf("ヘッダーが出力に含まれていない: %q", out)
+	}
+
+	if !strings.Contains(out, "gopls") {
+		t.Fatalf("gopls が出力に含まれていない: %q", out)
+	}
+
+	if !strings.Contains(out, "v0.17.1") {
+		t.Fatalf("バージョンが出力に含まれていない: %q", out)
+	}
+
+	if !strings.Contains(out, "@latest") {
+		t.Fatalf("@latest が出力に含まれていない: %q", out)
+	}
+
+	if !strings.Contains(out, "go.targets") {
+		t.Fatalf("ヒントメッセージが出力に含まれていない: %q", out)
+	}
+}
+
+func TestPrintGoDiscoverResult_WithSkipped(t *testing.T) {
+	result := &updater.DiscoverResult{
+		Detected: []updater.GoBinaryInfo{
+			{
+				BinaryName:       "gopls",
+				PackagePath:      "golang.org/x/tools/gopls",
+				InstalledVersion: "v0.17.1",
+			},
+		},
+		Skipped: []updater.SkippedBinary{
+			{Name: "unknown.exe", Reason: "Go モジュール情報なし"},
+			{Name: "backup~", Reason: "バックアップファイル"},
+		},
+	}
+
+	out := captureStdout(t, func() {
+		printGoDiscoverResult(result)
+	})
+
+	if !strings.Contains(out, "スキップ:") {
+		t.Fatalf("スキップセクションが出力に含まれていない: %q", out)
+	}
+
+	if !strings.Contains(out, "unknown.exe") {
+		t.Fatalf("unknown.exe が出力に含まれていない: %q", out)
+	}
+
+	if !strings.Contains(out, "backup~") {
+		t.Fatalf("backup~ が出力に含まれていない: %q", out)
+	}
+}
+
+func TestPrintGoDiscoverResult_SkippedSectionOmittedWhenEmpty(t *testing.T) {
+	result := &updater.DiscoverResult{
+		Detected: []updater.GoBinaryInfo{
+			{
+				BinaryName:  "mytool",
+				PackagePath: "github.com/foo/mytool",
+			},
+		},
+		// Skipped は空
+	}
+
+	out := captureStdout(t, func() {
+		printGoDiscoverResult(result)
+	})
+
+	if strings.Contains(out, "スキップ:") {
+		t.Fatalf("スキップが 0 件なのにスキップセクションが表示されている: %q", out)
+	}
+}
+
+func TestResolveDiscoverManagers_ErrorMessage(t *testing.T) {
+	t.Parallel()
+
+	// stderr のメッセージに未対応マネージャ名が含まれることを確認
+	oldStderr := os.Stderr
+
+	r, w, pipeErr := os.Pipe()
+	if pipeErr != nil {
+		t.Fatalf("os.Pipe() failed: %v", pipeErr)
+	}
+
+	os.Stderr = w
+
+	_, err := resolveDiscoverManagers("brew")
+
+	if closeErr := w.Close(); closeErr != nil {
+		t.Logf("w.Close() 失敗（無視）: %v", closeErr)
+	}
+
+	os.Stderr = oldStderr
+
+	var buf bytes.Buffer
+	if _, copyErr := io.Copy(&buf, r); copyErr != nil {
+		t.Logf("stderr 読み取り失敗（無視）: %v", copyErr)
+	}
+
+	if err == nil {
+		t.Fatal("未対応マネージャでエラーが返らなかった")
+	}
+
+	stderrMsg := buf.String()
+	if !strings.Contains(stderrMsg, "brew") {
+		t.Fatalf("stderr にマネージャ名「brew」が含まれていない: %q", stderrMsg)
+	}
+
+	if !strings.Contains(err.Error(), "brew") {
+		t.Fatalf("エラーメッセージにマネージャ名「brew」が含まれていない: %q", err.Error())
+	}
+}
+
+func TestDiscoverManager_UnsupportedManagerReturnsError(t *testing.T) {
+	t.Parallel()
+
+	err := discoverManager(context.Background(), "apt")
+	if err == nil {
+		t.Fatal("未対応マネージャでエラーが返らなかった")
+	}
+
+	if !strings.Contains(err.Error(), "apt") {
+		t.Fatalf("エラーメッセージに「apt」が含まれていない: %q", err.Error())
+	}
+}
+
+// TestPrintGoDiscoverResult_InstalledVersionEmpty は InstalledVersion が空の場合に
+// バージョン表記が省略されることを確認します。
+func TestPrintGoDiscoverResult_InstalledVersionEmpty(t *testing.T) {
+	result := &updater.DiscoverResult{
+		Detected: []updater.GoBinaryInfo{
+			{
+				BinaryName:  "mytool",
+				PackagePath: "github.com/foo/mytool",
+				// InstalledVersion は空
+			},
+		},
+	}
+
+	out := captureStdout(t, func() {
+		printGoDiscoverResult(result)
+	})
+
+	if strings.Contains(out, "インストール済み:") {
+		t.Fatalf("バージョン未設定なのに「インストール済み:」が表示されている: %q", out)
+	}
+
+	if !strings.Contains(out, "github.com/foo/mytool@latest") {
+		t.Fatalf("UpdateTarget の出力 %q が含まれていない: %q", "github.com/foo/mytool@latest", out)
+	}
+}

--- a/cmd/dsx/sys_discover_test.go
+++ b/cmd/dsx/sys_discover_test.go
@@ -1,10 +1,7 @@
 package main
 
 import (
-	"bytes"
 	"context"
-	"io"
-	"os"
 	"strings"
 	"testing"
 
@@ -131,8 +128,8 @@ func TestPrintGoDiscoverResult_NoneDetected(t *testing.T) {
 		printGoDiscoverResult(result)
 	})
 
-	if !strings.Contains(out, "検出されませんでした") {
-		t.Fatalf("出力に「検出されませんでした」が含まれていない: %q", out)
+	if !strings.Contains(out, "ありませんでした") {
+		t.Fatalf("出力に「ありませんでした」が含まれていない: %q", out)
 	}
 }
 
@@ -156,7 +153,7 @@ func TestPrintGoDiscoverResult_WithDetected(t *testing.T) {
 		printGoDiscoverResult(result)
 	})
 
-	if !strings.Contains(out, "検出された Go ツール:") {
+	if !strings.Contains(out, "[go] 検出されたバイナリ:") {
 		t.Fatalf("ヘッダーが出力に含まれていない: %q", out)
 	}
 
@@ -232,36 +229,10 @@ func TestPrintGoDiscoverResult_SkippedSectionOmittedWhenEmpty(t *testing.T) {
 func TestResolveDiscoverManagers_ErrorMessage(t *testing.T) {
 	t.Parallel()
 
-	// stderr のメッセージに未対応マネージャ名が含まれることを確認
-	oldStderr := os.Stderr
-
-	r, w, pipeErr := os.Pipe()
-	if pipeErr != nil {
-		t.Fatalf("os.Pipe() failed: %v", pipeErr)
-	}
-
-	os.Stderr = w
-
+	// エラーメッセージに未対応マネージャ名が含まれることを確認
 	_, err := resolveDiscoverManagers("brew")
-
-	if closeErr := w.Close(); closeErr != nil {
-		t.Logf("w.Close() 失敗（無視）: %v", closeErr)
-	}
-
-	os.Stderr = oldStderr
-
-	var buf bytes.Buffer
-	if _, copyErr := io.Copy(&buf, r); copyErr != nil {
-		t.Logf("stderr 読み取り失敗（無視）: %v", copyErr)
-	}
-
 	if err == nil {
 		t.Fatal("未対応マネージャでエラーが返らなかった")
-	}
-
-	stderrMsg := buf.String()
-	if !strings.Contains(stderrMsg, "brew") {
-		t.Fatalf("stderr にマネージャ名「brew」が含まれていない: %q", stderrMsg)
 	}
 
 	if !strings.Contains(err.Error(), "brew") {

--- a/tasks.md
+++ b/tasks.md
@@ -57,6 +57,17 @@
 
 ---
 
+## Issue #47: dsx sys discover コマンド実装（PR #53、CI確認待ち）
+
+- [x] `cmd/dsx/sys_discover.go` 実装（`dsx sys discover` コマンド）
+- [x] `cmd/dsx/sys_discover_test.go` テスト追加（table-driven・境界値・エラー系）
+- [x] `task check` 通過
+- [x] PR #53 作成・Copilot レビュー 3 サイクル対応（計 8 スレッド全件 accept）
+- [x] CHANGELOG.md 更新
+- [ ] PR #53 マージ
+
+---
+
 ## Backlog / 改善候補
 
 ### `AutoStash` オプションの修正（設定が機能していないバグ）


### PR DESCRIPTION
## 概要

Issue #47 に対応し、dsx sys discover コマンドを実装しました。

## 変更内容

### 新規ファイル

- **cmd/dsx/sys_discover.go**: \dsx sys discover\ コマンド本体
  - \--manager\ フラグで対象マネージャを絞り込み可能（省略時は全対応マネージャを対象）
  - Phase 1 スコープとして \go\ マネージャのみ対応
  - go バイナリのスキャン結果（検出済み・スキップ）を stdout に整形表示
  - \internal/updater\ の \DiscoverGoBinaries()\ 等（#45/#46 実装済み）を活用

- **cmd/dsx/sys_discover_test.go**: テストファイル
  - Table-driven tests（TestIsSupportedDiscoverManager, TestResolveDiscoverManagers）
  - stdout キャプチャテスト（TestPrintGoDiscoverResult_* 5種）
  - 境界値・エラー系を網羅

## 使用例

\\\ash
# 全対応マネージャを対象にスキャン
dsx sys discover

# go マネージャのみ対象
dsx sys discover --manager go

# 未対応マネージャを指定するとエラー
dsx sys discover --manager apt
\\\

## 出力フォーマット例

\\\
[go] 検出されたバイナリ:
  mytool               github.com/foo/mytool@latest (インストール済み: v1.2.3)
  othertool            github.com/bar/othertool@latest

[go] スキップ:
  skippedtool          理由: ...
\\\

## テスト

- \	ask check\（fmt → vet → test → lint）: fmt/vet/test 全て通過
- lint: 新規ファイルの指摘 0 件（既存ファイルの goconst 警告 25 件は本 PR 以前からの既存問題）

Closes #47