### PR TITLE
fix(updater): Go targets 未設定時のメッセージ改善・テスト追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - `DiscoverGoBinariesInDir(ctx, binDir)` を実装（指定ディレクトリ内の Go バイナリをスキャンし、`go version -m` で情報を収集）
 - `DiscoverGoBinaries(ctx)` を実装（`GOBIN` → `GOPATH/bin` → `~/go/bin` の順で自動解決してスキャン）
 - `dsx sys discover` コマンドを追加（`GOBIN`/`GOPATH/bin`/`~/go/bin` 内の Go バイナリを検出し、モジュール情報と共に一覧表示）
+- Go updater の `targets` 未設定時のメッセージを改善し、`dsx sys discover` コマンドへ誘導するヒントを追加
 
 ### Changed
 

--- a/internal/updater/go.go
+++ b/internal/updater/go.go
@@ -68,7 +68,8 @@ func (g *GoUpdater) Check(ctx context.Context) (*CheckResult, error) {
 	// 設定された targets 数を「更新可能」として返す
 	if len(g.targets) == 0 {
 		return &CheckResult{
-			Message: "更新対象のGoツールが設定されていません",
+			Message: "Go updater の targets は未設定です。\n" +
+				"$GOBIN / $GOPATH/bin に既存の Go バイナリがある場合は `dsx sys discover` で go.targets 候補を確認できます。",
 		}, nil
 	}
 
@@ -94,7 +95,8 @@ func (g *GoUpdater) Update(ctx context.Context, opts UpdateOptions) (*UpdateResu
 	result := &UpdateResult{}
 
 	if len(g.targets) == 0 {
-		result.Message = "更新対象のGoツールが設定されていません"
+		result.Message = "Go updater の targets は未設定です。\n" +
+			"$GOBIN / $GOPATH/bin に既存の Go バイナリがある場合は `dsx sys discover` で go.targets 候補を確認できます。"
 		return result, nil
 	}
 

--- a/internal/updater/go.go
+++ b/internal/updater/go.go
@@ -13,6 +13,11 @@ import (
 	"github.com/scottlz0310/dsx/internal/config"
 )
 
+// goTargetsEmptyMessage は go.targets が未設定の際に Check / Update が返すメッセージです。
+// 単一の定数で管理することで文言の不整合を防ぎます。
+const goTargetsEmptyMessage = "Go updater の targets は未設定です。\n" +
+	"$GOBIN / $GOPATH/bin に既存の Go バイナリがある場合は `dsx sys discover` で go.targets 候補を確認できます。"
+
 // GoUpdater は Go ツール (go install) の更新を管理します。
 // go install コマンドでインストールしたバイナリを最新版に更新します。
 type GoUpdater struct {
@@ -68,8 +73,7 @@ func (g *GoUpdater) Check(ctx context.Context) (*CheckResult, error) {
 	// 設定された targets 数を「更新可能」として返す
 	if len(g.targets) == 0 {
 		return &CheckResult{
-			Message: "Go updater の targets は未設定です。\n" +
-				"$GOBIN / $GOPATH/bin に既存の Go バイナリがある場合は `dsx sys discover` で go.targets 候補を確認できます。",
+			Message: goTargetsEmptyMessage,
 		}, nil
 	}
 
@@ -95,8 +99,7 @@ func (g *GoUpdater) Update(ctx context.Context, opts UpdateOptions) (*UpdateResu
 	result := &UpdateResult{}
 
 	if len(g.targets) == 0 {
-		result.Message = "Go updater の targets は未設定です。\n" +
-			"$GOBIN / $GOPATH/bin に既存の Go バイナリがある場合は `dsx sys discover` で go.targets 候補を確認できます。"
+		result.Message = goTargetsEmptyMessage
 		return result, nil
 	}
 

--- a/internal/updater/go_test.go
+++ b/internal/updater/go_test.go
@@ -108,7 +108,7 @@ func TestGoUpdater_Check(t *testing.T) {
 		require.NotNil(t, got)
 
 		assert.Equal(t, 0, got.AvailableUpdates)
-		assert.Contains(t, got.Message, "設定されていません")
+		assert.Contains(t, got.Message, "targets は未設定")
 		assert.Empty(t, got.Packages)
 	})
 
@@ -143,7 +143,7 @@ func TestGoUpdater_Update_DryRun(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, got)
 
-		assert.Contains(t, got.Message, "設定されていません")
+		assert.Contains(t, got.Message, "targets は未設定")
 		assert.Empty(t, got.Packages)
 		assert.Equal(t, 0, got.UpdatedCount)
 	})
@@ -468,4 +468,52 @@ func TestDiscoverInDir_ContextCanceled(t *testing.T) {
 	_, err := discoverInDir(ctx, dir, fakeRunCmd)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, context.Canceled)
+}
+
+// TestGoUpdater_Check_EmptyTargets は targets 未設定時に dsx sys discover へのヒントを含む
+// メッセージが返ることを検証します。
+func TestGoUpdater_Check_EmptyTargets(t *testing.T) {
+	tests := []struct {
+		name         string
+		targets      []string
+		wantMsgParts []string
+		wantUpdates  int
+	}{
+		{
+			name:    "targets未設定でdiscover案内メッセージを返す",
+			targets: nil,
+			wantMsgParts: []string{
+				"targets は未設定",
+				"dsx sys discover",
+				"go.targets",
+			},
+			wantUpdates: 0,
+		},
+		{
+			name:    "空スライスでもdiscover案内メッセージを返す",
+			targets: []string{},
+			wantMsgParts: []string{
+				"targets は未設定",
+				"dsx sys discover",
+			},
+			wantUpdates: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := &GoUpdater{targets: tt.targets}
+
+			got, err := g.Check(context.Background())
+			require.NoError(t, err)
+			require.NotNil(t, got)
+
+			assert.Equal(t, tt.wantUpdates, got.AvailableUpdates)
+			assert.Empty(t, got.Packages)
+
+			for _, part := range tt.wantMsgParts {
+				assert.Contains(t, got.Message, part, "メッセージに %q が含まれていない", part)
+			}
+		})
+	}
 }

--- a/internal/updater/go_test.go
+++ b/internal/updater/go_test.go
@@ -144,6 +144,8 @@ func TestGoUpdater_Update_DryRun(t *testing.T) {
 		require.NotNil(t, got)
 
 		assert.Contains(t, got.Message, "targets は未設定")
+		assert.Contains(t, got.Message, "dsx sys discover")
+		assert.Contains(t, got.Message, "go.targets")
 		assert.Empty(t, got.Packages)
 		assert.Equal(t, 0, got.UpdatedCount)
 	})
@@ -495,6 +497,7 @@ func TestGoUpdater_Check_EmptyTargets(t *testing.T) {
 			wantMsgParts: []string{
 				"targets は未設定",
 				"dsx sys discover",
+				"go.targets",
 			},
 			wantUpdates: 0,
 		},

--- a/tasks.md
+++ b/tasks.md
@@ -57,14 +57,24 @@
 
 ---
 
-## Issue #47: dsx sys discover コマンド実装（PR #53、CI確認待ち）
+## Issue #47: dsx sys discover コマンド実装（PR #53、マージ済み）
 
 - [x] `cmd/dsx/sys_discover.go` 実装（`dsx sys discover` コマンド）
 - [x] `cmd/dsx/sys_discover_test.go` テスト追加（table-driven・境界値・エラー系）
 - [x] `task check` 通過
 - [x] PR #53 作成・Copilot レビュー 3 サイクル対応（計 8 スレッド全件 accept）
 - [x] CHANGELOG.md 更新
-- [ ] PR #53 マージ
+- [x] PR #53 マージ
+
+---
+
+## Issue #48: targets 未設定メッセージ改善 + テスト追加
+
+- [x] `internal/updater/go.go` の `Check()`/`Update()` 内メッセージを改善（`dsx sys discover` 誘導ヒント追加）
+- [x] `internal/updater/go_test.go` に `TestGoUpdater_Check_EmptyTargets` 追加（改善後メッセージ文言検証）
+- [x] `task check` 通過（テスト全件パス）
+- [x] CHANGELOG.md 更新
+- [ ] PR 作成・マージ
 
 ---
 


### PR DESCRIPTION
## 概要

Issue #48 の実装。Go updater の 	argets が未設定の場合に表示されるメッセージを改善し、dsx sys discover コマンドへ誘導するヒントを追加しました。

## 変更内容

### T4: メッセージ改善（internal/updater/go.go）

Check() / Update() 内の targets 未設定時メッセージを変更:

**変更前:**
\\\
更新対象のGoツールが設定されていません
\\\

**変更後:**
\\\
Go updater の targets は未設定です。
\ / \/bin に既存の Go バイナリがある場合は \dsx sys discover\ で go.targets 候補を確認できます。
\\\

### T5: テスト追加（internal/updater/go_test.go）

- \TestGoUpdater_Check_EmptyTargets\（table-driven）: 改善後メッセージに \	argets は未設定\ / \dsx sys discover\ / \go.targets\ の各フレーズが含まれることを検証
- 既存 \TestGoUpdater_Check\ / \TestGoUpdater_Update_DryRun\ のアサーションを新メッセージに合わせて更新

## 確認事項

- [x] \	ask check\ 全パス（fmt / vet / test / lint）
- [x] lint エラーはすべて pre-existing（本 PR で新規追加なし）
- [x] \CHANGELOG.md\ 更新
- [x] \	asks.md\ 更新

Closes #48