### PR TITLE
release: v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ## [Unreleased]
 
+## [v0.4.0] - 2026-05-09
+
 ### Added
 
 - `dsx sys discover --apply` フラグを追加。検出した Go バイナリを `config.yaml` の `go.targets` へ自動書き込みする機能を実装

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -302,7 +302,8 @@
 
 ---
 
-[Unreleased]: https://github.com/scottlz0310/dsx/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/scottlz0310/dsx/compare/v0.4.0...HEAD
+[v0.4.0]: https://github.com/scottlz0310/dsx/compare/v0.3.0...v0.4.0
 [v0.3.0]: https://github.com/scottlz0310/dsx/compare/v0.2.5...v0.3.0
 [v0.2.5]: https://github.com/scottlz0310/dsx/compare/v0.2.4...v0.2.5
 [v0.2.4]: https://github.com/scottlz0310/dsx/compare/v0.2.3...v0.2.4

--- a/tasks.md
+++ b/tasks.md
@@ -91,7 +91,7 @@
 - [x] テスト追加（`TestPackagePathFrom`・`TestMergeGoTargets`・`TestPrintGoApplyDryRun_*`・`TestSaveAtomic`）
 - [x] `task check` 通過（fmt/vet/test/lint）
 - [x] `CHANGELOG.md` 更新
-- [ ] PR 作成・マージ（close #56）
+- [x] PR 作成・マージ（close #56）→ PR #57 マージ済み
 
 ---
 


### PR DESCRIPTION
## v0.4.0 リリース準備

### 変更内容

- `CHANGELOG.md`: `[Unreleased]` → `[v0.4.0] - 2026-05-09` に昇格
- `tasks.md`: Issue #56 の PR タスク（PR #57 マージ済み）をクローズ

### リリース内容（v0.3.0 → v0.4.0）

- `dsx sys discover --apply`: 検出した Go バイナリを `go.targets` に自動書き込み
- `dsx sys discover --apply --dry-run`: 書き込みプレビュー表示
- `config.SaveAtomic()`: タイムスタンプ付きバックアップ + アトミック書き込み
- `--dry-run` 単独指定時のエラー処理
- `config.yaml` 未存在時の新規作成対応

🤖 Generated with [Claude Code](https://claude.com/claude-code)