### PR TITLE
fix(updater): pnpm v11 で [WARN] 行が stdout に混入し JSON パースが失敗する問題を修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- pnpm v11 で `pnpm outdated -g --format json` の stdout に `[WARN]` 診断行が混入し JSON パースが失敗する問題を修正（`parseOutdatedJSON` でブラケットタグ行を除外してから JSON を抽出するよう変更）
+
 ## [v0.4.0] - 2026-05-09
 
 ### Added

--- a/internal/updater/pnpm.go
+++ b/internal/updater/pnpm.go
@@ -249,12 +249,27 @@ func (p *PnpmUpdater) parseOutdatedJSON(output []byte) ([]PackageInfo, error) {
 		return []PackageInfo{}, nil
 	}
 
-	packages := p.parseOutdatedArrayJSON([]byte(trimmed))
+	// pnpm v11 では stdout に [WARN] 等の診断行が混入するため、
+	// ブラケットタグで始まる行を除外して JSON 部分のみを抽出する。
+	var jsonLines []string
+	for _, line := range strings.Split(trimmed, "\n") {
+		t := strings.TrimSpace(line)
+		if strings.HasPrefix(t, "[WARN]") || strings.HasPrefix(t, "[ERR]") || strings.HasPrefix(t, "[ERROR]") {
+			continue
+		}
+		jsonLines = append(jsonLines, line)
+	}
+	jsonStr := strings.TrimSpace(strings.Join(jsonLines, "\n"))
+	if jsonStr == "" {
+		return nil, fmt.Errorf("JSON が見つかりません: %s", trimmed)
+	}
+
+	packages := p.parseOutdatedArrayJSON([]byte(jsonStr))
 	if packages != nil {
 		return packages, nil
 	}
 
-	return p.parseOutdatedMapJSON([]byte(trimmed))
+	return p.parseOutdatedMapJSON([]byte(jsonStr))
 }
 
 func (p *PnpmUpdater) parseOutdatedArrayJSON(output []byte) []PackageInfo {

--- a/internal/updater/pnpm.go
+++ b/internal/updater/pnpm.go
@@ -257,8 +257,10 @@ func (p *PnpmUpdater) parseOutdatedJSON(output []byte) ([]PackageInfo, error) {
 		if strings.HasPrefix(t, "[WARN]") || strings.HasPrefix(t, "[ERR]") || strings.HasPrefix(t, "[ERROR]") {
 			continue
 		}
+
 		jsonLines = append(jsonLines, line)
 	}
+
 	jsonStr := strings.TrimSpace(strings.Join(jsonLines, "\n"))
 	if jsonStr == "" {
 		return nil, fmt.Errorf("JSON が見つかりません: %s", trimmed)

--- a/internal/updater/pnpm.go
+++ b/internal/updater/pnpm.go
@@ -249,8 +249,8 @@ func (p *PnpmUpdater) parseOutdatedJSON(output []byte) ([]PackageInfo, error) {
 		return []PackageInfo{}, nil
 	}
 
-	// pnpm v11 では stdout に [WARN] 等の診断行が混入するため、
-	// ブラケットタグで始まる行を除外して JSON 部分のみを抽出する。
+	// pnpm v11 では stdout に [WARN] / [ERR] / [ERROR] の診断行が混入するため、
+	// これらのタグで始まる行を除外して JSON 部分のみを抽出する。
 	var jsonLines []string
 	for _, line := range strings.Split(trimmed, "\n") {
 		t := strings.TrimSpace(line)
@@ -263,7 +263,7 @@ func (p *PnpmUpdater) parseOutdatedJSON(output []byte) ([]PackageInfo, error) {
 
 	jsonStr := strings.TrimSpace(strings.Join(jsonLines, "\n"))
 	if jsonStr == "" {
-		return nil, fmt.Errorf("JSON が見つかりません: %s", trimmed)
+		return nil, fmt.Errorf("JSON が見つかりません")
 	}
 
 	packages := p.parseOutdatedArrayJSON([]byte(jsonStr))

--- a/internal/updater/pnpm_test.go
+++ b/internal/updater/pnpm_test.go
@@ -138,6 +138,24 @@ func TestPnpmUpdater_parseOutdatedJSON(t *testing.T) {
 ]`),
 			want: map[string]PackageInfo{},
 		},
+		{
+			name: "pnpm v11 の [WARN] 行が JSON の前に混入しても解析できる",
+			output: []byte("[WARN] Using --global skips the package manager check for this project\n" +
+				`{"eslint": {"current":"8.0.0","latest":"9.0.0"}}`),
+			want: map[string]PackageInfo{
+				"eslint": {
+					Name:           "eslint",
+					CurrentVersion: "8.0.0",
+					NewVersion:     "9.0.0",
+				},
+			},
+		},
+		{
+			name:        "JSON が存在しない出力はエラー",
+			output:      []byte("[WARN] something went wrong"),
+			expectErr:   true,
+			errContains: "JSON が見つかりません",
+		},
 	}
 
 	for _, tt := range tests {

--- a/tasks.md
+++ b/tasks.md
@@ -95,6 +95,16 @@
 
 ---
 
+## pnpm v11 対応: parseOutdatedJSON が WARNING 行で失敗する問題の修正
+
+- [x] `internal/updater/pnpm.go` の `parseOutdatedJSON` で `[WARN]`/`[ERR]`/`[ERROR]` 行をフィルタリングしてから JSON 抽出するよう修正
+- [x] `internal/updater/pnpm_test.go` に `[WARN]` 混入ケースおよび JSON なし出力のテストケースを追加
+- [x] `task check` 通過（全テストパス）
+- [x] `CHANGELOG.md` 更新
+- [ ] PR 作成・マージ
+
+---
+
 ## Backlog / 改善候補
 
 ### `AutoStash` オプションの修正（設定が機能していないバグ）
@@ -128,6 +138,19 @@ pull がスキップされ `git pull --rebase --autostash` が一切実行され
 - [x] `printRepoUpdateSummary()` に「pull スキップ: N 件」行と一覧を追加
 
 対象: `cmd/dsx/repo.go`
+
+---
+
+## v0.4.0 リリース準備（完了）
+
+- [x] `task check` 通過確認（fmt/vet/test/lint）
+- [x] バージョン: v0.4.0（マイナーバージョンアップ）
+- [x] CHANGELOG.md: [Unreleased] → [v0.4.0] - 2026-05-09
+- [x] PR 作成・マージ（[#58](https://github.com/scottlz0310/dsx/pull/58)）
+- [x] `release/v0.4.0` ブランチ削除（ローカル + リモート参照プルーン）
+- [x] `v0.4.0` タグ発行・push → goreleaser が GitHub Release を自動作成
+- [x] GitHub Release ページを見やすく編集
+- [x] Issue #56 クローズ済み（PR #57 マージ時に自動クローズ）
 
 ---
 


### PR DESCRIPTION
## 概要

pnpm v11 では `pnpm outdated -g --format json` の stdout に診断行が混入するようになり、JSON パースが失敗する問題を修正します。

## 問題

pnpm v10 以前:
```
stdout: {}
stderr: [WARN] Using --global skips the package manager check for this project
```

pnpm v11 以降:
```
stdout: [WARN] Using --global skips the package manager check for this project
        {}
```

警告が stderr から stdout に移動したため、`json.Unmarshal` が `[WARN]...` から始まる文字列を受け取り `invalid character 'W' looking for beginning of value` エラーになっていた。

## 修正内容

`parseOutdatedJSON`（`internal/updater/pnpm.go`）内で `[WARN]`/`[ERR]`/`[ERROR]` で始まる行をフィルタリングしてから JSON 部分を抽出するよう変更。

- 配列形式（`[...]`）とオブジェクト形式（`{...}`）の両パーサーを維持
- JSON が一切含まれない出力には「JSON が見つかりません」エラーを返す

## テスト

- `pnpm v11 の [WARN] 行が JSON の前に混入しても解析できる` テストケースを追加
- `JSON が存在しない出力はエラー` テストケースを追加

## チェックリスト

- [x] `go build ./...` 成功
- [x] `go test ./...` 全テストパス
- [x] lint 通過
- [x] `CHANGELOG.md` 更新
- [x] `tasks.md` 更新