### PR TITLE
chore(ci): Codecov カバレッジ計測を有効化 + v0.4.1 リリース準備

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,7 @@ jobs:
         run: go test -v -race -coverprofile=coverage.out -covermode=atomic ./...
 
       - name: Upload coverage to Codecov
+        if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
         uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,8 +66,9 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v6
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.out
-          fail_ci_if_error: false
+          fail_ci_if_error: true
           verbose: true
 
   test-windows:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,16 @@
 
 ## [Unreleased]
 
+## [v0.4.1] - 2026-05-10
+
 ### Fixed
 
 - pnpm v11 で `pnpm outdated -g --format json` の stdout に `[WARN]` 診断行が混入し JSON パースが失敗する問題を修正（`parseOutdatedJSON` でブラケットタグ行を除外してから JSON を抽出するよう変更）
+
+### Changed
+
+- Codecov アップロードに `CODECOV_TOKEN` を追加し、ブランチ保護下でのカバレッジ計測を有効化
+- `codecov.yml` を追加し、プロジェクト・パッチカバレッジの閾値（各 1% 低下まで許容）と PR コメント表示を設定
 
 ## [v0.4.0] - 2026-05-09
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,15 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: auto
+        threshold: 1%
+
+comment:
+  layout: "reach,diff,flags,files"
+  behavior: default
+  require_changes: false

--- a/tasks.md
+++ b/tasks.md
@@ -105,6 +105,16 @@
 
 ---
 
+## Codecov カバレッジ計測の有効化 + v0.4.1 リリース準備
+
+- [x] `ci.yml` に `CODECOV_TOKEN` を追加（`fail_ci_if_error: true` に変更）
+- [x] `codecov.yml` を新規追加（閾値・PR コメント設定）
+- [x] `CHANGELOG.md` を `[v0.4.1]` としてリリース準備
+- [ ] PR 作成・マージ
+- [ ] `v0.4.1` タグを打ってリリース
+
+---
+
 ## Backlog / 改善候補
 
 ### `AutoStash` オプションの修正（設定が機能していないバグ）

--- a/tasks.md
+++ b/tasks.md
@@ -101,7 +101,7 @@
 - [x] `internal/updater/pnpm_test.go` に `[WARN]` 混入ケースおよび JSON なし出力のテストケースを追加
 - [x] `task check` 通過（全テストパス）
 - [x] `CHANGELOG.md` 更新
-- [ ] PR 作成・マージ
+- [x] PR 作成・マージ（PR #59 マージ済み）
 
 ---
 


### PR DESCRIPTION
## 概要

Codecov でカバレッジ計測できるよう CI を整備し、v0.4.1 のリリース準備を行います。

## 変更内容

### CI 設定（`.github/workflows/ci.yml`）
- `codecov/codecov-action@v6` に `token: ${{ secrets.CODECOV_TOKEN }}` を追加
  - ブランチ保護下で `HTTP 400: Token required because branch is protected` が発生していた問題を解消
- `fail_ci_if_error: false` → `true` に変更（token 設定済みのためアップロード失敗を CI エラーとして検出）

### Codecov 設定（`codecov.yml` 新規追加）
- プロジェクト・パッチカバレッジの閾値: 前回比 1% 低下まで許容（`target: auto`）
- PR コメント: `reach,diff,flags,files` レイアウトで表示

### リリース準備
- `CHANGELOG.md`: `[Unreleased]` を `[v0.4.1] - 2026-05-10` として昇格

## マージ後の作業（別途実施）
- `v0.4.1` タグを打つ → GoReleaser が自動でリリース

## チェックリスト
- [x] lint 通過
- [x] test 通過
- [x] `CHANGELOG.md` 更新
- [x] `tasks.md` 更新