### PR TITLE
[codex] Go updaterで最新版判定を追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@
 
 ## [Unreleased]
 
+### Added
+
+- Go updater で `go version -m` と `go list -m -json <module>@latest` を使った best-effort の installed/latest 比較を追加し、最新版の Go ツールは `go install` をスキップするよう改善
+
+### Changed
+
+- `dsx self-update` の更新判定ロジックを `internal/selfupdate` に分離し、Go updater からも同じ判定基準を再利用できるよう整理
+
+### Fixed
+
+- `go.targets` に `github.com/scottlz0310/dsx/cmd/dsx` が含まれる場合でも Go updater では `dsx` 本体を `go install` しないよう修正。最新版なら非エラースキップし、更新がある場合のみ `dsx self-update` を案内するエラーに変更
+
 ## [v0.4.1] - 2026-05-10
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -187,6 +187,11 @@ dsx sys discover --manager go # Go バイナリのみスキャン
 `snapd unavailable` の環境では `snap` を利用不可として自動スキップします。
 `sys.enable` に未インストールのマネージャが含まれている場合は、警告を表示してスキップし、利用可能なマネージャのみ継続実行します。
 
+Go updater は `go.targets` のうち `@latest` 対象について、インストール済みバイナリの module 情報と `go list -m -json <module>@latest` を best-effort で比較します。
+すでに最新版の Go ツールは `go install` をスキップし、判定不能なツールや固定バージョン target は従来通り安全側で `go install` を実行します。
+`go.targets` に `github.com/scottlz0310/dsx/cmd/dsx` が含まれる場合、Go updater では dsx 本体を更新しません。
+dsx 本体が最新版なら非エラーでスキップし、新しい dsx バージョンがある場合は `dsx self-update` を案内します。
+
 ### リポジトリ管理 (`repo`)
 ```
 dsx repo update       # 管理下リポジトリを更新（fetch + pull --rebase）

--- a/cmd/dsx/self_update.go
+++ b/cmd/dsx/self_update.go
@@ -2,67 +2,30 @@ package main
 
 import (
 	"context"
-	"encoding/json"
-	"errors"
 	"fmt"
-	"net/http"
 	"os"
 	"os/exec"
 	"runtime"
-	"strconv"
-	"strings"
-	"time"
 
+	"github.com/scottlz0310/dsx/internal/selfupdate"
 	"github.com/spf13/cobra"
 )
 
-const (
-	selfUpdateLatestReleaseAPI = "https://api.github.com/repos/scottlz0310/dsx/releases/latest"
-	selfUpdateGoInstallPkg     = "github.com/scottlz0310/dsx/cmd/dsx"
-	selfUpdateCheckTimeout     = 2 * time.Second
-	selfUpdateDevelVersion     = "(devel)"
-)
-
-type selfUpdateInfo struct {
-	CurrentVersion string
-	LatestVersion  string
-	ReleaseURL     string
-}
-
-type semverCore struct {
-	Major int
-	Minor int
-	Patch int
-}
-
-type latestReleaseResponse struct {
-	TagName string `json:"tag_name"`
-	HTMLURL string `json:"html_url"`
-}
+type selfUpdateInfo = selfupdate.Info
+type semverCore = selfupdate.SemverCore
 
 var (
 	selfUpdateCheckOnly bool
 
 	selfUpdateCheckStep        = checkSelfUpdateAvailable
 	selfUpdateApplyStep        = applySelfUpdate
-	selfUpdateFetchReleaseStep = fetchLatestRelease
+	selfUpdateFetchReleaseStep = func(ctx context.Context) (string, string, error) {
+		return selfupdate.FetchLatestRelease(ctx, version)
+	}
 )
 
-func normalizeSelfUpdateVersion(version string) string {
-	normalized := strings.TrimSpace(version)
-	if normalized == "" {
-		return normalized
-	}
-
-	if !strings.HasPrefix(normalized, "v") {
-		normalized = "v" + normalized
-	}
-
-	return normalized
-}
-
 func selfUpdateInstallTarget(version string) string {
-	return selfUpdateGoInstallPkg + "@" + normalizeSelfUpdateVersion(version)
+	return selfupdate.InstallTarget(version)
 }
 
 var selfUpdateCmd = &cobra.Command{
@@ -139,76 +102,7 @@ func printSelfUpdateNoticeAtEnd() {
 }
 
 func checkSelfUpdateAvailable(ctx context.Context, currentVersion string) (*selfUpdateInfo, error) {
-	if isDevelopmentBuildVersion(currentVersion) {
-		return nil, nil
-	}
-
-	currentCore, ok := parseSemverCore(currentVersion)
-	if !ok {
-		return nil, nil
-	}
-
-	checkCtx, cancel := context.WithTimeout(ctx, selfUpdateCheckTimeout)
-	defer cancel()
-
-	latestVersion, releaseURL, err := selfUpdateFetchReleaseStep(checkCtx)
-	if err != nil {
-		return nil, err
-	}
-
-	latestCore, ok := parseSemverCore(latestVersion)
-	if !ok {
-		return nil, nil
-	}
-
-	if compareSemverCore(latestCore, currentCore) <= 0 {
-		return nil, nil
-	}
-
-	return &selfUpdateInfo{
-		CurrentVersion: strings.TrimSpace(currentVersion),
-		LatestVersion:  strings.TrimSpace(latestVersion),
-		ReleaseURL:     strings.TrimSpace(releaseURL),
-	}, nil
-}
-
-func fetchLatestRelease(ctx context.Context) (latestVersion, releaseURL string, err error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, selfUpdateLatestReleaseAPI, http.NoBody)
-	if err != nil {
-		return "", "", err
-	}
-
-	req.Header.Set("Accept", "application/vnd.github+json")
-	req.Header.Set("User-Agent", "dsx/"+strings.TrimSpace(version))
-
-	client := &http.Client{}
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return "", "", err
-	}
-
-	defer func() {
-		if closeErr := resp.Body.Close(); closeErr != nil {
-			return
-		}
-	}()
-
-	if resp.StatusCode != http.StatusOK {
-		return "", "", fmt.Errorf("最新リリース取得に失敗しました: status=%s", resp.Status)
-	}
-
-	var payload latestReleaseResponse
-	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
-		return "", "", err
-	}
-
-	tag := strings.TrimSpace(payload.TagName)
-	if tag == "" {
-		return "", "", errors.New("最新リリースのタグが取得できませんでした")
-	}
-
-	return tag, strings.TrimSpace(payload.HTMLURL), nil
+	return selfupdate.CheckAvailable(ctx, currentVersion, selfUpdateFetchReleaseStep)
 }
 
 func applySelfUpdate(ctx context.Context, version string) error {
@@ -238,68 +132,13 @@ func applySelfUpdate(ctx context.Context, version string) error {
 }
 
 func isDevelopmentBuildVersion(v string) bool {
-	trimmed := strings.TrimSpace(v)
-	return trimmed == "" || trimmed == "dev" || trimmed == selfUpdateDevelVersion
+	return selfupdate.IsDevelopmentBuildVersion(v)
 }
 
 func parseSemverCore(v string) (semverCore, bool) {
-	trimmed := strings.TrimSpace(v)
-	trimmed = strings.TrimPrefix(trimmed, "v")
-	parts := strings.SplitN(trimmed, "-", 2)
-	coreAndBuild := strings.SplitN(parts[0], "+", 2)
-	core := strings.TrimSpace(coreAndBuild[0])
-
-	segments := strings.Split(core, ".")
-	if len(segments) != 3 {
-		return semverCore{}, false
-	}
-
-	major, err := strconv.Atoi(strings.TrimSpace(segments[0]))
-	if err != nil {
-		return semverCore{}, false
-	}
-
-	minor, err := strconv.Atoi(strings.TrimSpace(segments[1]))
-	if err != nil {
-		return semverCore{}, false
-	}
-
-	patch, err := strconv.Atoi(strings.TrimSpace(segments[2]))
-	if err != nil {
-		return semverCore{}, false
-	}
-
-	return semverCore{
-		Major: major,
-		Minor: minor,
-		Patch: patch,
-	}, true
+	return selfupdate.ParseSemverCore(v)
 }
 
 func compareSemverCore(left, right semverCore) int {
-	if left.Major != right.Major {
-		if left.Major > right.Major {
-			return 1
-		}
-
-		return -1
-	}
-
-	if left.Minor != right.Minor {
-		if left.Minor > right.Minor {
-			return 1
-		}
-
-		return -1
-	}
-
-	if left.Patch != right.Patch {
-		if left.Patch > right.Patch {
-			return 1
-		}
-
-		return -1
-	}
-
-	return 0
+	return selfupdate.CompareSemverCore(left, right)
 }

--- a/cmd/dsx/sys.go
+++ b/cmd/dsx/sys.go
@@ -102,6 +102,8 @@ func runSysUpdate(cmd *cobra.Command, args []string) error {
 		fmt.Fprintf(os.Stderr, "⚠️  %v\n", err)
 	}
 
+	configureUpdaterRuntimeVersion(enabledUpdaters, version)
+
 	tuiReq, err := resolveTUIRequest(cfg.UI.TUI, cmd.Flags().Changed("tui"), sysTUI, cmd.Flags().Changed("no-tui"), sysNoTUI)
 	if err != nil {
 		return err
@@ -247,8 +249,9 @@ func loadSysUpdateConfig(cmd *cobra.Command) (*config.Config, updater.UpdateOpti
 	}
 
 	opts := updater.UpdateOptions{
-		DryRun:  cfg.Control.DryRun,
-		Verbose: sysVerbose,
+		DryRun:         cfg.Control.DryRun,
+		Verbose:        sysVerbose,
+		CurrentVersion: version,
 	}
 
 	return cfg, opts
@@ -455,6 +458,21 @@ func resolveSysJobs(configJobs, flagJobs int) int {
 	}
 
 	return 1
+}
+
+type runtimeVersionConfigurer interface {
+	ConfigureRuntimeVersion(string)
+}
+
+func configureUpdaterRuntimeVersion(updaters []updater.Updater, currentVersion string) {
+	for _, u := range updaters {
+		configurer, ok := u.(runtimeVersionConfigurer)
+		if !ok {
+			continue
+		}
+
+		configurer.ConfigureRuntimeVersion(currentVersion)
+	}
 }
 
 func splitUpdatersForExecution(updaters []updater.Updater) (exclusive, parallel []updater.Updater) {

--- a/internal/selfupdate/selfupdate.go
+++ b/internal/selfupdate/selfupdate.go
@@ -21,6 +21,11 @@ const (
 	DevelVersion     = "(devel)"
 )
 
+var (
+	latestReleaseAPIURL     = LatestReleaseAPI
+	latestReleaseHTTPClient = http.DefaultClient
+)
+
 // Info は self-update の更新確認結果を保持します。
 type Info struct {
 	CurrentVersion string
@@ -105,7 +110,7 @@ func CheckAvailable(ctx context.Context, currentVersion string, fetch ReleaseFet
 
 // FetchLatestRelease は GitHub Releases API から最新リリースタグを取得します。
 func FetchLatestRelease(ctx context.Context, userAgentVersion string) (latestVersion, releaseURL string, err error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, LatestReleaseAPI, http.NoBody)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, latestReleaseAPIURL, http.NoBody)
 	if err != nil {
 		return "", "", err
 	}
@@ -113,7 +118,10 @@ func FetchLatestRelease(ctx context.Context, userAgentVersion string) (latestVer
 	req.Header.Set("Accept", "application/vnd.github+json")
 	req.Header.Set("User-Agent", "dsx/"+strings.TrimSpace(userAgentVersion))
 
-	client := &http.Client{}
+	client := latestReleaseHTTPClient
+	if client == nil {
+		client = http.DefaultClient
+	}
 
 	resp, err := client.Do(req)
 	if err != nil {

--- a/internal/selfupdate/selfupdate.go
+++ b/internal/selfupdate/selfupdate.go
@@ -1,0 +1,214 @@
+// Package selfupdate は dsx 本体の更新確認に関する共通ロジックを提供します。
+package selfupdate
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	// LatestReleaseAPI は dsx の最新 GitHub Release を取得する API です。
+	LatestReleaseAPI = "https://api.github.com/repos/scottlz0310/dsx/releases/latest"
+	// GoInstallPackage は dsx 本体を go install する際の package path です。
+	GoInstallPackage = "github.com/scottlz0310/dsx/cmd/dsx"
+	CheckTimeout     = 2 * time.Second
+	DevelVersion     = "(devel)"
+)
+
+// Info は self-update の更新確認結果を保持します。
+type Info struct {
+	CurrentVersion string
+	LatestVersion  string
+	ReleaseURL     string
+}
+
+// SemverCore は比較に使う major/minor/patch だけを保持します。
+type SemverCore struct {
+	Major int
+	Minor int
+	Patch int
+}
+
+type latestReleaseResponse struct {
+	TagName string `json:"tag_name"`
+	HTMLURL string `json:"html_url"`
+}
+
+// ReleaseFetcher は最新リリース情報を取得する関数です。
+type ReleaseFetcher func(context.Context) (latestVersion, releaseURL string, err error)
+
+// NormalizeVersion は v prefix を揃えたバージョン文字列を返します。
+func NormalizeVersion(version string) string {
+	normalized := strings.TrimSpace(version)
+	if normalized == "" {
+		return normalized
+	}
+
+	if !strings.HasPrefix(normalized, "v") {
+		normalized = "v" + normalized
+	}
+
+	return normalized
+}
+
+// InstallTarget は dsx 本体の go install target を返します。
+func InstallTarget(version string) string {
+	return GoInstallPackage + "@" + NormalizeVersion(version)
+}
+
+// CheckAvailable は現在バージョンと最新リリースを比較し、更新がある場合のみ Info を返します。
+func CheckAvailable(ctx context.Context, currentVersion string, fetch ReleaseFetcher) (*Info, error) {
+	if IsDevelopmentBuildVersion(currentVersion) {
+		return nil, nil
+	}
+
+	currentCore, ok := ParseSemverCore(currentVersion)
+	if !ok {
+		return nil, nil
+	}
+
+	checkCtx, cancel := context.WithTimeout(ctx, CheckTimeout)
+	defer cancel()
+
+	if fetch == nil {
+		fetch = func(ctx context.Context) (string, string, error) {
+			return FetchLatestRelease(ctx, currentVersion)
+		}
+	}
+
+	latestVersion, releaseURL, err := fetch(checkCtx)
+	if err != nil {
+		return nil, err
+	}
+
+	latestCore, ok := ParseSemverCore(latestVersion)
+	if !ok {
+		return nil, nil
+	}
+
+	if CompareSemverCore(latestCore, currentCore) <= 0 {
+		return nil, nil
+	}
+
+	return &Info{
+		CurrentVersion: strings.TrimSpace(currentVersion),
+		LatestVersion:  strings.TrimSpace(latestVersion),
+		ReleaseURL:     strings.TrimSpace(releaseURL),
+	}, nil
+}
+
+// FetchLatestRelease は GitHub Releases API から最新リリースタグを取得します。
+func FetchLatestRelease(ctx context.Context, userAgentVersion string) (latestVersion, releaseURL string, err error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, LatestReleaseAPI, http.NoBody)
+	if err != nil {
+		return "", "", err
+	}
+
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("User-Agent", "dsx/"+strings.TrimSpace(userAgentVersion))
+
+	client := &http.Client{}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", "", err
+	}
+
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			return
+		}
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", "", fmt.Errorf("最新リリース取得に失敗しました: status=%s", resp.Status)
+	}
+
+	var payload latestReleaseResponse
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return "", "", err
+	}
+
+	tag := strings.TrimSpace(payload.TagName)
+	if tag == "" {
+		return "", "", errors.New("最新リリースのタグが取得できませんでした")
+	}
+
+	return tag, strings.TrimSpace(payload.HTMLURL), nil
+}
+
+// IsDevelopmentBuildVersion は更新比較できない開発版バージョンかどうかを返します。
+func IsDevelopmentBuildVersion(v string) bool {
+	trimmed := strings.TrimSpace(v)
+	return trimmed == "" || trimmed == "dev" || trimmed == DevelVersion
+}
+
+// ParseSemverCore は semver 文字列から major/minor/patch を取り出します。
+func ParseSemverCore(v string) (SemverCore, bool) {
+	trimmed := strings.TrimSpace(v)
+	trimmed = strings.TrimPrefix(trimmed, "v")
+	parts := strings.SplitN(trimmed, "-", 2)
+	coreAndBuild := strings.SplitN(parts[0], "+", 2)
+	core := strings.TrimSpace(coreAndBuild[0])
+
+	segments := strings.Split(core, ".")
+	if len(segments) != 3 {
+		return SemverCore{}, false
+	}
+
+	major, err := strconv.Atoi(strings.TrimSpace(segments[0]))
+	if err != nil {
+		return SemverCore{}, false
+	}
+
+	minor, err := strconv.Atoi(strings.TrimSpace(segments[1]))
+	if err != nil {
+		return SemverCore{}, false
+	}
+
+	patch, err := strconv.Atoi(strings.TrimSpace(segments[2]))
+	if err != nil {
+		return SemverCore{}, false
+	}
+
+	return SemverCore{
+		Major: major,
+		Minor: minor,
+		Patch: patch,
+	}, true
+}
+
+// CompareSemverCore は left と right を比較し、left が大きければ 1、小さければ -1、同値なら 0 を返します。
+func CompareSemverCore(left, right SemverCore) int {
+	if left.Major != right.Major {
+		if left.Major > right.Major {
+			return 1
+		}
+
+		return -1
+	}
+
+	if left.Minor != right.Minor {
+		if left.Minor > right.Minor {
+			return 1
+		}
+
+		return -1
+	}
+
+	if left.Patch != right.Patch {
+		if left.Patch > right.Patch {
+			return 1
+		}
+
+		return -1
+	}
+
+	return 0
+}

--- a/internal/selfupdate/selfupdate_test.go
+++ b/internal/selfupdate/selfupdate_test.go
@@ -1,0 +1,274 @@
+package selfupdate
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeVersion(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "空文字列", in: "", want: ""},
+		{name: "vあり", in: "v1.2.3", want: "v1.2.3"},
+		{name: "vなし", in: "1.2.3", want: "v1.2.3"},
+		{name: "前後空白", in: " 1.2.3 ", want: "v1.2.3"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, NormalizeVersion(tt.in))
+		})
+	}
+}
+
+func TestInstallTarget(t *testing.T) {
+	assert.Equal(t, GoInstallPackage+"@v1.2.3", InstallTarget("1.2.3"))
+	assert.Equal(t, GoInstallPackage+"@v1.2.3", InstallTarget("v1.2.3"))
+}
+
+func TestIsDevelopmentBuildVersion(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{name: "空文字列", in: "", want: true},
+		{name: "dev", in: "dev", want: true},
+		{name: "devel", in: DevelVersion, want: true},
+		{name: "前後空白つきdev", in: " dev ", want: true},
+		{name: "通常バージョン", in: "v1.2.3", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsDevelopmentBuildVersion(tt.in))
+		})
+	}
+}
+
+func TestParseSemverCore(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want SemverCore
+		ok   bool
+	}{
+		{name: "vあり", in: "v1.2.3", want: SemverCore{Major: 1, Minor: 2, Patch: 3}, ok: true},
+		{name: "vなし", in: "1.2.3", want: SemverCore{Major: 1, Minor: 2, Patch: 3}, ok: true},
+		{name: "prereleaseはcoreだけ比較", in: "v1.2.3-beta.1", want: SemverCore{Major: 1, Minor: 2, Patch: 3}, ok: true},
+		{name: "build metadataはcoreだけ比較", in: "v1.2.3+meta", want: SemverCore{Major: 1, Minor: 2, Patch: 3}, ok: true},
+		{name: "前後空白", in: " v1.2.3 ", want: SemverCore{Major: 1, Minor: 2, Patch: 3}, ok: true},
+		{name: "segment不足", in: "v1.2", ok: false},
+		{name: "segment過多", in: "v1.2.3.4", ok: false},
+		{name: "major不正", in: "vx.2.3", ok: false},
+		{name: "minor不正", in: "v1.x.3", ok: false},
+		{name: "patch不正", in: "v1.2.x", ok: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := ParseSemverCore(tt.in)
+			assert.Equal(t, tt.ok, ok)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestCompareSemverCore(t *testing.T) {
+	tests := []struct {
+		name  string
+		left  SemverCore
+		right SemverCore
+		want  int
+	}{
+		{name: "majorが大きい", left: SemverCore{Major: 2}, right: SemverCore{Major: 1}, want: 1},
+		{name: "majorが小さい", left: SemverCore{Major: 1}, right: SemverCore{Major: 2}, want: -1},
+		{name: "minorが大きい", left: SemverCore{Major: 1, Minor: 3}, right: SemverCore{Major: 1, Minor: 2}, want: 1},
+		{name: "minorが小さい", left: SemverCore{Major: 1, Minor: 2}, right: SemverCore{Major: 1, Minor: 3}, want: -1},
+		{name: "patchが大きい", left: SemverCore{Major: 1, Minor: 2, Patch: 4}, right: SemverCore{Major: 1, Minor: 2, Patch: 3}, want: 1},
+		{name: "patchが小さい", left: SemverCore{Major: 1, Minor: 2, Patch: 3}, right: SemverCore{Major: 1, Minor: 2, Patch: 4}, want: -1},
+		{name: "同値", left: SemverCore{Major: 1, Minor: 2, Patch: 3}, right: SemverCore{Major: 1, Minor: 2, Patch: 3}, want: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, CompareSemverCore(tt.left, tt.right))
+		})
+	}
+}
+
+func TestCheckAvailable(t *testing.T) {
+	tests := []struct {
+		name            string
+		currentVersion  string
+		fetchVersion    string
+		fetchURL        string
+		fetchErr        error
+		wantFetchCalls  int
+		wantInfo        *Info
+		wantErrContains string
+	}{
+		{
+			name:           "開発版は取得しない",
+			currentVersion: "dev",
+		},
+		{
+			name:           "現在バージョン不正は取得しない",
+			currentVersion: "not-semver",
+		},
+		{
+			name:            "取得エラーを返す",
+			currentVersion:  "v1.2.3",
+			fetchErr:        errors.New("api error"),
+			wantFetchCalls:  1,
+			wantErrContains: "api error",
+		},
+		{
+			name:           "最新バージョン不正は更新なし",
+			currentVersion: "v1.2.3",
+			fetchVersion:   "latest",
+			wantFetchCalls: 1,
+		},
+		{
+			name:           "同一バージョンは更新なし",
+			currentVersion: "v1.2.3",
+			fetchVersion:   "v1.2.3",
+			wantFetchCalls: 1,
+		},
+		{
+			name:           "古い最新バージョンは更新なし",
+			currentVersion: "v1.2.3",
+			fetchVersion:   "v1.2.2",
+			wantFetchCalls: 1,
+		},
+		{
+			name:           "新しい最新バージョンはInfoを返す",
+			currentVersion: " v1.2.3 ",
+			fetchVersion:   " v1.2.4 ",
+			fetchURL:       " https://example.com/release ",
+			wantFetchCalls: 1,
+			wantInfo: &Info{
+				CurrentVersion: "v1.2.3",
+				LatestVersion:  "v1.2.4",
+				ReleaseURL:     "https://example.com/release",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fetchCalls := 0
+			fetch := func(context.Context) (string, string, error) {
+				fetchCalls++
+				return tt.fetchVersion, tt.fetchURL, tt.fetchErr
+			}
+
+			got, err := CheckAvailable(context.Background(), tt.currentVersion, fetch)
+			if tt.wantErrContains != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErrContains)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.wantInfo, got)
+			}
+
+			assert.Equal(t, tt.wantFetchCalls, fetchCalls)
+		})
+	}
+}
+
+func TestFetchLatestRelease(t *testing.T) {
+	tests := []struct {
+		name            string
+		status          int
+		body            string
+		wantVersion     string
+		wantURL         string
+		wantErrContains string
+	}{
+		{
+			name:        "正常に最新リリースを取得する",
+			status:      http.StatusOK,
+			body:        `{"tag_name":" v1.2.3 ","html_url":" https://example.com/release "}`,
+			wantVersion: "v1.2.3",
+			wantURL:     "https://example.com/release",
+		},
+		{
+			name:            "非200はエラー",
+			status:          http.StatusForbidden,
+			body:            `{}`,
+			wantErrContains: "status=403 Forbidden",
+		},
+		{
+			name:            "JSON不正はエラー",
+			status:          http.StatusOK,
+			body:            `{"tag_name":`,
+			wantErrContains: "unexpected EOF",
+		},
+		{
+			name:            "タグ空はエラー",
+			status:          http.StatusOK,
+			body:            `{"tag_name":"   "}`,
+			wantErrContains: "最新リリースのタグ",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, http.MethodGet, r.Method)
+				assert.Equal(t, "application/vnd.github+json", r.Header.Get("Accept"))
+				assert.Equal(t, "dsx/v1.2.0", r.Header.Get("User-Agent"))
+
+				w.WriteHeader(tt.status)
+				_, err := w.Write([]byte(tt.body))
+				require.NoError(t, err)
+			}))
+			defer server.Close()
+
+			restore := restoreFetchLatestReleaseHTTP(server.URL, server.Client())
+			defer restore()
+
+			gotVersion, gotURL, err := FetchLatestRelease(context.Background(), "v1.2.0")
+			if tt.wantErrContains != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErrContains)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantVersion, gotVersion)
+			assert.Equal(t, tt.wantURL, gotURL)
+		})
+	}
+}
+
+func TestFetchLatestRelease_InvalidAPIURL(t *testing.T) {
+	restore := restoreFetchLatestReleaseHTTP("://bad-url", http.DefaultClient)
+	defer restore()
+
+	_, _, err := FetchLatestRelease(context.Background(), "v1.2.0")
+	require.Error(t, err)
+}
+
+func restoreFetchLatestReleaseHTTP(apiURL string, client *http.Client) func() {
+	oldURL := latestReleaseAPIURL
+	oldClient := latestReleaseHTTPClient
+
+	latestReleaseAPIURL = apiURL
+	latestReleaseHTTPClient = client
+
+	return func() {
+		latestReleaseAPIURL = oldURL
+		latestReleaseHTTPClient = oldClient
+	}
+}

--- a/internal/updater/go.go
+++ b/internal/updater/go.go
@@ -3,6 +3,7 @@ package updater
 import (
 	"bufio"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -11,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/scottlz0310/dsx/internal/config"
+	"github.com/scottlz0310/dsx/internal/selfupdate"
 )
 
 // goTargetsEmptyMessage は go.targets が未設定の際に Check / Update が返すメッセージです。
@@ -24,6 +26,12 @@ type GoUpdater struct {
 	// targets は更新対象のパッケージパス一覧
 	// 例: ["golang.org/x/tools/gopls@latest", "github.com/golangci/golangci-lint/cmd/golangci-lint@latest"]
 	targets []string
+
+	discoverGoBinaries  func(context.Context) (*DiscoverResult, error)
+	latestModuleVersion func(context.Context, string) (string, error)
+	installGoTarget     func(context.Context, string) error
+	selfUpdateCheck     func(context.Context, string) (*selfupdate.Info, error)
+	currentVersion      string
 }
 
 // 起動時にレジストリに登録
@@ -69,29 +77,23 @@ func (g *GoUpdater) Configure(cfg config.ManagerConfig) error {
 }
 
 func (g *GoUpdater) Check(ctx context.Context) (*CheckResult, error) {
-	// Go ツールは明示的なバージョン確認が難しいため、
-	// 設定された targets 数を「更新可能」として返す
 	if len(g.targets) == 0 {
 		return &CheckResult{
 			Message: goTargetsEmptyMessage,
 		}, nil
 	}
 
-	packages := make([]PackageInfo, 0, len(g.targets))
-
-	for _, target := range g.targets {
-		// パッケージパスからツール名を抽出
-		name := extractToolName(target)
-		packages = append(packages, PackageInfo{
-			Name:       name,
-			NewVersion: latestVersionSuffix,
-		})
+	plan, err := g.planGoTargets(ctx, g.currentVersion)
+	if err != nil {
+		return nil, err
 	}
+
+	packages := planPackages(plan.installTargets())
 
 	return &CheckResult{
 		AvailableUpdates: len(packages),
 		Packages:         packages,
-		Message:          fmt.Sprintf("%d 件のGoツールが更新対象です", len(packages)),
+		Message:          plan.checkMessage(),
 	}, nil
 }
 
@@ -103,39 +105,31 @@ func (g *GoUpdater) Update(ctx context.Context, opts UpdateOptions) (*UpdateResu
 		return result, nil
 	}
 
-	if opts.DryRun {
-		packages := make([]PackageInfo, 0, len(g.targets))
-		for _, target := range g.targets {
-			packages = append(packages, PackageInfo{
-				Name:       extractToolName(target),
-				NewVersion: latestVersionSuffix,
-			})
-		}
+	currentVersion := strings.TrimSpace(opts.CurrentVersion)
+	if currentVersion == "" {
+		currentVersion = g.currentVersion
+	}
 
-		result.Packages = packages
-		result.Message = fmt.Sprintf("%d 件のGoツールを更新予定（DryRunモード）", len(g.targets))
+	plan, err := g.planGoTargets(ctx, currentVersion)
+	if err != nil {
+		return nil, err
+	}
+
+	if opts.DryRun {
+		result.Packages = planPackages(plan.installTargets())
+		result.Message = plan.dryRunMessage()
 
 		return result, nil
 	}
 
 	// 各ツールを順番に更新
-	for _, target := range g.targets {
-		toolName := extractToolName(target)
-
-		// @latest が付いていない場合は追加
-		pkg := target
-		if !strings.Contains(pkg, "@") {
-			pkg += latestVersionSuffix
-		}
+	for _, target := range plan.installTargets() {
+		toolName := target.ToolName
+		pkg := target.InstallTarget
 
 		fmt.Printf("  📦 %s をインストール中...\n", toolName)
 
-		cmd := exec.CommandContext(ctx, "go", "install", pkg)
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
-		cmd.Env = os.Environ()
-
-		if err := cmd.Run(); err != nil {
+		if err := g.runGoInstall(ctx, pkg); err != nil {
 			result.FailedCount++
 			result.Errors = append(result.Errors, fmt.Errorf("%s: %w", toolName, err))
 
@@ -143,19 +137,455 @@ func (g *GoUpdater) Update(ctx context.Context, opts UpdateOptions) (*UpdateResu
 		}
 
 		result.UpdatedCount++
-		result.Packages = append(result.Packages, PackageInfo{
-			Name:       toolName,
-			NewVersion: latestVersionSuffix,
-		})
+		result.Packages = append(result.Packages, target.PackageInfo())
 	}
 
 	if result.FailedCount > 0 {
 		result.Message = fmt.Sprintf("%d 件更新、%d 件失敗", result.UpdatedCount, result.FailedCount)
 	} else {
-		result.Message = fmt.Sprintf("%d 件のGoツールを更新しました", result.UpdatedCount)
+		result.Message = plan.updateMessage(result.UpdatedCount)
 	}
 
 	return result, nil
+}
+
+// ConfigureRuntimeVersion は実行中 dsx のバージョンを Go updater に渡します。
+func (g *GoUpdater) ConfigureRuntimeVersion(currentVersion string) {
+	g.currentVersion = currentVersion
+}
+
+type goTargetAction string
+
+const (
+	goTargetInstallUpdate  goTargetAction = "install_update"
+	goTargetInstallUnknown goTargetAction = "install_unknown"
+	goTargetInstallPinned  goTargetAction = "install_pinned"
+	goTargetSkipLatest     goTargetAction = "skip_latest"
+	goTargetSkipSelf       goTargetAction = "skip_self"
+)
+
+type parsedGoTarget struct {
+	Raw           string
+	PackagePath   string
+	Version       string
+	InstallTarget string
+	CompareLatest bool
+}
+
+type goTargetDecision struct {
+	RawTarget      string
+	PackagePath    string
+	InstallTarget  string
+	ToolName       string
+	CurrentVersion string
+	LatestVersion  string
+	Reason         string
+	Action         goTargetAction
+}
+
+type goUpdatePlan struct {
+	Decisions        []*goTargetDecision
+	DiscoveryWarning string
+}
+
+type goListModuleJSON struct {
+	Version string `json:"Version"`
+}
+
+type latestModuleResult struct {
+	Version string
+	Err     error
+}
+
+func (g *GoUpdater) planGoTargets(ctx context.Context, currentVersion string) (*goUpdatePlan, error) {
+	discovered, discoveryWarning, err := g.discoverInstalledGoBinaries(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	installedByPackage := buildGoBinaryMap(discovered)
+	latestCache := make(map[string]latestModuleResult)
+	plan := &goUpdatePlan{DiscoveryWarning: discoveryWarning}
+
+	for _, rawTarget := range g.targets {
+		decision, err := g.planGoTarget(ctx, rawTarget, installedByPackage, latestCache, currentVersion)
+		if err != nil {
+			return nil, err
+		}
+
+		plan.Decisions = append(plan.Decisions, decision)
+	}
+
+	return plan, nil
+}
+
+func (g *GoUpdater) planGoTarget(ctx context.Context, rawTarget string, installedByPackage map[string]*GoBinaryInfo, latestCache map[string]latestModuleResult, currentVersion string) (*goTargetDecision, error) {
+	target := parseGoTarget(rawTarget)
+	if isDSXSelfPackage(target.PackagePath) {
+		return g.planDSXSelfTarget(ctx, target, currentVersion)
+	}
+
+	if !target.CompareLatest {
+		return newPinnedDecision(target), nil
+	}
+
+	info, ok := installedByPackage[target.PackagePath]
+	if !ok {
+		return newUnknownDecision(target, "対応するバイナリが見つかりません"), nil
+	}
+
+	return g.planLatestGoTarget(ctx, target, info, latestCache), nil
+}
+
+func (g *GoUpdater) planLatestGoTarget(ctx context.Context, target parsedGoTarget, info *GoBinaryInfo, latestCache map[string]latestModuleResult) *goTargetDecision {
+	if info.ModulePath == "" {
+		return newUnknownDecision(target, "ModulePath が空です")
+	}
+
+	if info.InstalledVersion == "" || info.InstalledVersion == selfupdate.DevelVersion {
+		return newUnknownDecision(target, "InstalledVersion が比較不能です")
+	}
+
+	latest := g.cachedLatestModuleVersion(ctx, info.ModulePath, latestCache)
+	if latest.Err != nil {
+		return newUnknownDecision(target, fmt.Sprintf("latest version の取得に失敗しました: %v", latest.Err))
+	}
+
+	if latest.Version == "" {
+		return newUnknownDecision(target, "latest version が空です")
+	}
+
+	if info.InstalledVersion == latest.Version {
+		return newLatestSkipDecision(target, info, latest.Version)
+	}
+
+	return newUpdateDecision(target, info, latest.Version)
+}
+
+func (g *GoUpdater) cachedLatestModuleVersion(ctx context.Context, modulePath string, latestCache map[string]latestModuleResult) latestModuleResult {
+	latest, ok := latestCache[modulePath]
+	if ok {
+		return latest
+	}
+
+	version, latestErr := g.getLatestModuleVersion(ctx, modulePath)
+	latest = latestModuleResult{Version: version, Err: latestErr}
+	latestCache[modulePath] = latest
+
+	return latest
+}
+
+func (g *GoUpdater) discoverInstalledGoBinaries(ctx context.Context) (*DiscoverResult, string, error) {
+	discover := g.discoverGoBinaries
+	if discover == nil {
+		discover = DiscoverGoBinaries
+	}
+
+	result, err := discover(ctx)
+	if err == nil {
+		return result, "", nil
+	}
+
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return nil, "", err
+	}
+
+	return &DiscoverResult{}, fmt.Sprintf("Go バイナリの検出に失敗したため、全 target を判定不能として扱います: %v", err), nil
+}
+
+func buildGoBinaryMap(result *DiscoverResult) map[string]*GoBinaryInfo {
+	installed := make(map[string]*GoBinaryInfo)
+	if result == nil {
+		return installed
+	}
+
+	for i := range result.Detected {
+		info := &result.Detected[i]
+		if info.PackagePath == "" {
+			continue
+		}
+
+		installed[info.PackagePath] = info
+	}
+
+	return installed
+}
+
+func parseGoTarget(raw string) parsedGoTarget {
+	trimmed := strings.TrimSpace(raw)
+	target := parsedGoTarget{
+		Raw:           trimmed,
+		PackagePath:   trimmed,
+		InstallTarget: trimmed + latestVersionSuffix,
+		CompareLatest: true,
+	}
+
+	if idx := strings.LastIndex(trimmed, "@"); idx >= 0 {
+		target.PackagePath = trimmed[:idx]
+		target.Version = trimmed[idx+1:]
+		target.InstallTarget = trimmed
+		target.CompareLatest = target.Version == "latest"
+	}
+
+	return target
+}
+
+func isDSXSelfPackage(packagePath string) bool {
+	return packagePath == selfupdate.GoInstallPackage
+}
+
+func (g *GoUpdater) planDSXSelfTarget(ctx context.Context, target parsedGoTarget, currentVersion string) (*goTargetDecision, error) {
+	decision := &goTargetDecision{
+		RawTarget:     target.Raw,
+		PackagePath:   target.PackagePath,
+		InstallTarget: target.InstallTarget,
+		ToolName:      extractToolName(target.PackagePath),
+		Action:        goTargetSkipSelf,
+		Reason:        "dsx 本体は Go updater では更新しません",
+	}
+
+	currentVersion = strings.TrimSpace(currentVersion)
+	if currentVersion == "" {
+		decision.Reason = "dsx 本体の更新有無を判定できないためスキップしました。必要に応じて `dsx self-update --check` を実行してください"
+		return decision, nil
+	}
+
+	check := g.selfUpdateCheck
+	if check == nil {
+		check = func(ctx context.Context, currentVersion string) (*selfupdate.Info, error) {
+			return selfupdate.CheckAvailable(ctx, currentVersion, nil)
+		}
+	}
+
+	info, err := check(ctx, currentVersion)
+	if err != nil {
+		decision.Reason = fmt.Sprintf("dsx 本体の更新有無を判定できないためスキップしました。必要に応じて `dsx self-update --check` を実行してください: %v", err)
+		return decision, nil
+	}
+
+	if info == nil {
+		decision.CurrentVersion = currentVersion
+		decision.Reason = "dsx 本体は最新版、または更新対象外のためスキップしました"
+		return decision, nil
+	}
+
+	return decision, fmt.Errorf(
+		"go updater の対象に dsx 本体が含まれています。dsx 本体は Go updater では更新できません。`dsx self-update` を実行してください: 現在 %s / 最新 %s",
+		info.CurrentVersion,
+		info.LatestVersion,
+	)
+}
+
+func newPinnedDecision(target parsedGoTarget) *goTargetDecision {
+	return &goTargetDecision{
+		RawTarget:     target.Raw,
+		PackagePath:   target.PackagePath,
+		InstallTarget: target.InstallTarget,
+		ToolName:      extractToolName(target.PackagePath),
+		LatestVersion: target.Version,
+		Reason:        "固定バージョン target のため従来通り実行します",
+		Action:        goTargetInstallPinned,
+	}
+}
+
+func newUnknownDecision(target parsedGoTarget, reason string) *goTargetDecision {
+	return &goTargetDecision{
+		RawTarget:     target.Raw,
+		PackagePath:   target.PackagePath,
+		InstallTarget: target.InstallTarget,
+		ToolName:      extractToolName(target.PackagePath),
+		LatestVersion: latestVersionSuffix,
+		Reason:        reason,
+		Action:        goTargetInstallUnknown,
+	}
+}
+
+func newLatestSkipDecision(target parsedGoTarget, info *GoBinaryInfo, latestVersion string) *goTargetDecision {
+	return &goTargetDecision{
+		RawTarget:      target.Raw,
+		PackagePath:    target.PackagePath,
+		InstallTarget:  target.InstallTarget,
+		ToolName:       extractToolName(target.PackagePath),
+		CurrentVersion: info.InstalledVersion,
+		LatestVersion:  latestVersion,
+		Reason:         "最新版です",
+		Action:         goTargetSkipLatest,
+	}
+}
+
+func newUpdateDecision(target parsedGoTarget, info *GoBinaryInfo, latestVersion string) *goTargetDecision {
+	return &goTargetDecision{
+		RawTarget:      target.Raw,
+		PackagePath:    target.PackagePath,
+		InstallTarget:  target.InstallTarget,
+		ToolName:       extractToolName(target.PackagePath),
+		CurrentVersion: info.InstalledVersion,
+		LatestVersion:  latestVersion,
+		Reason:         "更新があります",
+		Action:         goTargetInstallUpdate,
+	}
+}
+
+func (g *GoUpdater) getLatestModuleVersion(ctx context.Context, modulePath string) (string, error) {
+	run := g.latestModuleVersion
+	if run != nil {
+		return run(ctx, modulePath)
+	}
+
+	output, err := runCommandOutputWithLocaleC(
+		ctx,
+		"go",
+		[]string{"list", "-m", "-json", modulePath + latestVersionSuffix},
+		"go list -m -json の実行に失敗: %w",
+	)
+	if err != nil {
+		return "", err
+	}
+
+	var payload goListModuleJSON
+	if err := json.Unmarshal(output, &payload); err != nil {
+		return "", fmt.Errorf("go list -m -json の解析に失敗: %w", err)
+	}
+
+	return strings.TrimSpace(payload.Version), nil
+}
+
+func (g *GoUpdater) runGoInstall(ctx context.Context, target string) error {
+	run := g.installGoTarget
+	if run != nil {
+		return run(ctx, target)
+	}
+
+	cmd := exec.CommandContext(ctx, "go", "install", target)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Env = os.Environ()
+
+	return cmd.Run()
+}
+
+func (p *goUpdatePlan) installTargets() []*goTargetDecision {
+	targets := make([]*goTargetDecision, 0, len(p.Decisions))
+
+	for i := range p.Decisions {
+		decision := p.Decisions[i]
+		if decision.shouldInstall() {
+			targets = append(targets, decision)
+		}
+	}
+
+	return targets
+}
+
+func (p *goUpdatePlan) count(action goTargetAction) int {
+	count := 0
+	for i := range p.Decisions {
+		decision := p.Decisions[i]
+		if decision.Action == action {
+			count++
+		}
+	}
+
+	return count
+}
+
+func (p *goUpdatePlan) skippedCount() int {
+	return p.count(goTargetSkipLatest) + p.count(goTargetSkipSelf)
+}
+
+func (p *goUpdatePlan) unknownOrPinnedCount() int {
+	return p.count(goTargetInstallUnknown) + p.count(goTargetInstallPinned)
+}
+
+func (p *goUpdatePlan) checkMessage() string {
+	installCount := len(p.installTargets())
+	if installCount == 0 {
+		return p.noInstallMessage()
+	}
+
+	return p.summaryMessage(fmt.Sprintf("更新予定: %d 件", installCount))
+}
+
+func (p *goUpdatePlan) dryRunMessage() string {
+	installCount := len(p.installTargets())
+	if installCount == 0 {
+		return p.noInstallMessage() + "（DryRunモード）"
+	}
+
+	return p.summaryMessage(fmt.Sprintf("更新予定: %d 件", installCount)) + "（DryRunモード）"
+}
+
+func (p *goUpdatePlan) updateMessage(updatedCount int) string {
+	if updatedCount == 0 && len(p.installTargets()) == 0 {
+		return p.noInstallMessage()
+	}
+
+	return p.summaryMessage(fmt.Sprintf("更新: %d 件", updatedCount))
+}
+
+func (p *goUpdatePlan) noInstallMessage() string {
+	if p.skippedCount() > 0 {
+		message := fmt.Sprintf("Go ツールの更新対象はありません（スキップ: %d 件）", p.skippedCount())
+		if p.DiscoveryWarning != "" {
+			message += "\n" + p.DiscoveryWarning
+		}
+
+		return message
+	}
+
+	if p.DiscoveryWarning != "" {
+		return p.DiscoveryWarning
+	}
+
+	return "Go ツールの更新対象はありません"
+}
+
+func (p *goUpdatePlan) summaryMessage(prefix string) string {
+	message := fmt.Sprintf(
+		"%s / スキップ: %d 件 / 判定不能または固定バージョン: %d 件",
+		prefix,
+		p.skippedCount(),
+		p.unknownOrPinnedCount(),
+	)
+	if p.DiscoveryWarning != "" {
+		message += "\n" + p.DiscoveryWarning
+	}
+
+	return message
+}
+
+func (d *goTargetDecision) shouldInstall() bool {
+	return d.Action == goTargetInstallUpdate || d.Action == goTargetInstallUnknown || d.Action == goTargetInstallPinned
+}
+
+func (d *goTargetDecision) PackageInfo() PackageInfo {
+	return PackageInfo{
+		Name:           d.ToolName,
+		CurrentVersion: d.CurrentVersion,
+		NewVersion:     d.displayNewVersion(),
+	}
+}
+
+func (d *goTargetDecision) displayNewVersion() string {
+	if d.LatestVersion != "" {
+		return d.LatestVersion
+	}
+
+	if strings.HasSuffix(d.InstallTarget, latestVersionSuffix) {
+		return latestVersionSuffix
+	}
+
+	return d.InstallTarget
+}
+
+func planPackages(decisions []*goTargetDecision) []PackageInfo {
+	packages := make([]PackageInfo, 0, len(decisions))
+	for i := range decisions {
+		decision := decisions[i]
+		packages = append(packages, decision.PackageInfo())
+	}
+
+	return packages
 }
 
 // extractToolName はパッケージパスからツール名を抽出します

--- a/internal/updater/go.go
+++ b/internal/updater/go.go
@@ -299,7 +299,7 @@ func (g *GoUpdater) discoverInstalledGoBinaries(ctx context.Context) (*DiscoverR
 		return nil, "", err
 	}
 
-	return &DiscoverResult{}, fmt.Sprintf("Go バイナリの検出に失敗したため、全 target を判定不能として扱います: %v", err), nil
+	return &DiscoverResult{}, fmt.Sprintf("Go バイナリの検出に失敗したため、dsx 本体を除く @latest target は判定不能として扱います: %v", err), nil
 }
 
 func buildGoBinaryMap(result *DiscoverResult) map[string]*GoBinaryInfo {

--- a/internal/updater/go.go
+++ b/internal/updater/go.go
@@ -198,6 +198,16 @@ type latestModuleResult struct {
 }
 
 func (g *GoUpdater) planGoTargets(ctx context.Context, currentVersion string) (*goUpdatePlan, error) {
+	targets := make([]parsedGoTarget, 0, len(g.targets))
+	for _, rawTarget := range g.targets {
+		target, err := parseGoTarget(rawTarget)
+		if err != nil {
+			return nil, err
+		}
+
+		targets = append(targets, target)
+	}
+
 	discovered, discoveryWarning, err := g.discoverInstalledGoBinaries(ctx)
 	if err != nil {
 		return nil, err
@@ -207,8 +217,8 @@ func (g *GoUpdater) planGoTargets(ctx context.Context, currentVersion string) (*
 	latestCache := make(map[string]latestModuleResult)
 	plan := &goUpdatePlan{DiscoveryWarning: discoveryWarning}
 
-	for _, rawTarget := range g.targets {
-		decision, err := g.planGoTarget(ctx, rawTarget, installedByPackage, latestCache, currentVersion)
+	for _, target := range targets {
+		decision, err := g.planGoTarget(ctx, target, installedByPackage, latestCache, currentVersion)
 		if err != nil {
 			return nil, err
 		}
@@ -219,8 +229,7 @@ func (g *GoUpdater) planGoTargets(ctx context.Context, currentVersion string) (*
 	return plan, nil
 }
 
-func (g *GoUpdater) planGoTarget(ctx context.Context, rawTarget string, installedByPackage map[string]*GoBinaryInfo, latestCache map[string]latestModuleResult, currentVersion string) (*goTargetDecision, error) {
-	target := parseGoTarget(rawTarget)
+func (g *GoUpdater) planGoTarget(ctx context.Context, target parsedGoTarget, installedByPackage map[string]*GoBinaryInfo, latestCache map[string]latestModuleResult, currentVersion string) (*goTargetDecision, error) {
 	if isDSXSelfPackage(target.PackagePath) {
 		return g.planDSXSelfTarget(ctx, target, currentVersion)
 	}
@@ -311,8 +320,12 @@ func buildGoBinaryMap(result *DiscoverResult) map[string]*GoBinaryInfo {
 	return installed
 }
 
-func parseGoTarget(raw string) parsedGoTarget {
+func parseGoTarget(raw string) (parsedGoTarget, error) {
 	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return parsedGoTarget{}, fmt.Errorf("go.targets に空の target が含まれています")
+	}
+
 	target := parsedGoTarget{
 		Raw:           trimmed,
 		PackagePath:   trimmed,
@@ -321,13 +334,17 @@ func parseGoTarget(raw string) parsedGoTarget {
 	}
 
 	if idx := strings.LastIndex(trimmed, "@"); idx >= 0 {
+		if idx == 0 || idx == len(trimmed)-1 {
+			return parsedGoTarget{}, fmt.Errorf("go.targets に不正な target が含まれています: %q", trimmed)
+		}
+
 		target.PackagePath = trimmed[:idx]
 		target.Version = trimmed[idx+1:]
 		target.InstallTarget = trimmed
 		target.CompareLatest = target.Version == "latest"
 	}
 
-	return target
+	return target, nil
 }
 
 func isDSXSelfPackage(packagePath string) bool {

--- a/internal/updater/go.go
+++ b/internal/updater/go.go
@@ -442,9 +442,16 @@ func (g *GoUpdater) getLatestModuleVersion(ctx context.Context, modulePath strin
 		return "", err
 	}
 
+	return parseGoListModuleVersion(output)
+}
+
+func parseGoListModuleVersion(output []byte) (string, error) {
 	var payload goListModuleJSON
 	if err := json.Unmarshal(output, &payload); err != nil {
-		return "", fmt.Errorf("go list -m -json の解析に失敗: %w", err)
+		return "", fmt.Errorf(
+			"go list -m -json の解析に失敗: %w",
+			buildCommandOutputErr(err, output),
+		)
 	}
 
 	return strings.TrimSpace(payload.Version), nil

--- a/internal/updater/go_test.go
+++ b/internal/updater/go_test.go
@@ -9,9 +9,15 @@ import (
 	"testing"
 
 	"github.com/scottlz0310/dsx/internal/config"
+	"github.com/scottlz0310/dsx/internal/selfupdate"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type selfupdateInfoForTest struct {
+	CurrentVersion string
+	LatestVersion  string
+}
 
 func TestExtractToolName(t *testing.T) {
 	tests := []struct {
@@ -112,27 +118,213 @@ func TestGoUpdater_Check(t *testing.T) {
 		assert.Empty(t, got.Packages)
 	})
 
-	t.Run("更新対象あり", func(t *testing.T) {
-		g := &GoUpdater{
-			targets: []string{
-				"golang.org/x/tools/gopls@latest",
-				"github.com/fatih/gomodifytags",
+	tests := []struct {
+		name              string
+		targets           []string
+		detected          []GoBinaryInfo
+		latestVersions    map[string]string
+		latestErr         error
+		currentVersion    string
+		selfUpdateInfo    *selfupdateInfoForTest
+		selfUpdateErr     error
+		wantErrContains   string
+		wantUpdates       int
+		wantPackageNames  []string
+		wantNewVersions   []string
+		wantMessageParts  []string
+		wantLatestCallMap map[string]int
+	}{
+		{
+			name:    "installedとlatestが一致する場合はスキップ",
+			targets: []string{"github.com/foo/bar@latest"},
+			detected: []GoBinaryInfo{{
+				PackagePath:      "github.com/foo/bar",
+				ModulePath:       "github.com/foo",
+				InstalledVersion: "v1.0.0",
+			}},
+			latestVersions:   map[string]string{"github.com/foo": "v1.0.0"},
+			wantUpdates:      0,
+			wantMessageParts: []string{"更新対象はありません", "スキップ: 1 件"},
+		},
+		{
+			name:    "installedとlatestが異なる場合は更新対象",
+			targets: []string{"github.com/foo/bar@latest"},
+			detected: []GoBinaryInfo{{
+				PackagePath:      "github.com/foo/bar",
+				ModulePath:       "github.com/foo",
+				InstalledVersion: "v1.0.0",
+			}},
+			latestVersions:   map[string]string{"github.com/foo": "v1.1.0"},
+			wantUpdates:      1,
+			wantPackageNames: []string{"bar"},
+			wantNewVersions:  []string{"v1.1.0"},
+			wantMessageParts: []string{"更新予定: 1 件", "スキップ: 0 件"},
+		},
+		{
+			name:             "対応バイナリなしは判定不能として更新対象",
+			targets:          []string{"github.com/foo/missing"},
+			latestVersions:   map[string]string{},
+			wantUpdates:      1,
+			wantPackageNames: []string{"missing"},
+			wantNewVersions:  []string{"@latest"},
+			wantMessageParts: []string{"判定不能または固定バージョン: 1 件"},
+		},
+		{
+			name:    "ModulePath空は判定不能として更新対象",
+			targets: []string{"github.com/foo/bar@latest"},
+			detected: []GoBinaryInfo{{
+				PackagePath:      "github.com/foo/bar",
+				InstalledVersion: "v1.0.0",
+			}},
+			latestVersions:   map[string]string{},
+			wantUpdates:      1,
+			wantPackageNames: []string{"bar"},
+			wantNewVersions:  []string{"@latest"},
+		},
+		{
+			name:    "InstalledVersionがdevelなら判定不能として更新対象",
+			targets: []string{"github.com/foo/bar@latest"},
+			detected: []GoBinaryInfo{{
+				PackagePath:      "github.com/foo/bar",
+				ModulePath:       "github.com/foo",
+				InstalledVersion: "(devel)",
+			}},
+			latestVersions:   map[string]string{},
+			wantUpdates:      1,
+			wantPackageNames: []string{"bar"},
+			wantNewVersions:  []string{"@latest"},
+		},
+		{
+			name:    "go list失敗は判定不能として更新対象",
+			targets: []string{"github.com/foo/bar@latest"},
+			detected: []GoBinaryInfo{{
+				PackagePath:      "github.com/foo/bar",
+				ModulePath:       "github.com/foo",
+				InstalledVersion: "v1.0.0",
+			}},
+			latestErr:        errors.New("network error"),
+			wantUpdates:      1,
+			wantPackageNames: []string{"bar"},
+			wantNewVersions:  []string{"@latest"},
+		},
+		{
+			name:    "latest version空は判定不能として更新対象",
+			targets: []string{"github.com/foo/bar@latest"},
+			detected: []GoBinaryInfo{{
+				PackagePath:      "github.com/foo/bar",
+				ModulePath:       "github.com/foo",
+				InstalledVersion: "v1.0.0",
+			}},
+			latestVersions:   map[string]string{"github.com/foo": ""},
+			wantUpdates:      1,
+			wantPackageNames: []string{"bar"},
+			wantNewVersions:  []string{"@latest"},
+		},
+		{
+			name:             "固定バージョンtargetは従来通り更新対象",
+			targets:          []string{"github.com/foo/bar@v1.2.3"},
+			latestVersions:   map[string]string{},
+			wantUpdates:      1,
+			wantPackageNames: []string{"bar"},
+			wantNewVersions:  []string{"v1.2.3"},
+			wantMessageParts: []string{"判定不能または固定バージョン: 1 件"},
+		},
+		{
+			name:    "同一ModulePathはlatest取得をキャッシュする",
+			targets: []string{"github.com/foo/cmd/a@latest", "github.com/foo/cmd/b@latest"},
+			detected: []GoBinaryInfo{
+				{PackagePath: "github.com/foo/cmd/a", ModulePath: "github.com/foo", InstalledVersion: "v1.0.0"},
+				{PackagePath: "github.com/foo/cmd/b", ModulePath: "github.com/foo", InstalledVersion: "v1.0.0"},
 			},
-		}
+			latestVersions:    map[string]string{"github.com/foo": "v1.1.0"},
+			wantUpdates:       2,
+			wantPackageNames:  []string{"a", "b"},
+			wantNewVersions:   []string{"v1.1.0", "v1.1.0"},
+			wantLatestCallMap: map[string]int{"github.com/foo": 1},
+		},
+		{
+			name:           "dsx本体が最新版なら非エラースキップ",
+			targets:        []string{"github.com/scottlz0310/dsx/cmd/dsx@latest"},
+			currentVersion: "v0.4.1",
+			selfUpdateInfo: nil,
+			wantUpdates:    0,
+			wantMessageParts: []string{
+				"更新対象はありません",
+				"スキップ: 1 件",
+			},
+		},
+		{
+			name:            "dsx本体の更新ありはself-update誘導エラー",
+			targets:         []string{"github.com/scottlz0310/dsx/cmd/dsx@latest"},
+			currentVersion:  "v0.4.1",
+			selfUpdateInfo:  &selfupdateInfoForTest{CurrentVersion: "v0.4.1", LatestVersion: "v0.4.2"},
+			wantErrContains: "dsx self-update",
+		},
+		{
+			name:           "dsx本体の更新判定失敗は非エラースキップ",
+			targets:        []string{"github.com/scottlz0310/dsx/cmd/dsx@latest"},
+			currentVersion: "v0.4.1",
+			selfUpdateErr:  errors.New("api error"),
+			wantUpdates:    0,
+			wantMessageParts: []string{
+				"更新対象はありません",
+				"スキップ: 1 件",
+			},
+		},
+	}
 
-		got, err := g.Check(context.Background())
-		require.NoError(t, err)
-		require.NotNil(t, got)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			latestCalls := make(map[string]int)
+			g := newTestGoUpdater(tt.targets, tt.detected)
+			g.currentVersion = tt.currentVersion
+			g.latestModuleVersion = func(_ context.Context, modulePath string) (string, error) {
+				latestCalls[modulePath]++
 
-		assert.Equal(t, 2, got.AvailableUpdates)
-		assert.Contains(t, got.Message, "2 件")
-		require.Len(t, got.Packages, 2)
+				if tt.latestErr != nil {
+					return "", tt.latestErr
+				}
 
-		assert.Equal(t, "gopls", got.Packages[0].Name)
-		assert.Equal(t, "@latest", got.Packages[0].NewVersion)
-		assert.Equal(t, "gomodifytags", got.Packages[1].Name)
-		assert.Equal(t, "@latest", got.Packages[1].NewVersion)
-	})
+				return tt.latestVersions[modulePath], nil
+			}
+
+			g.selfUpdateCheck = func(_ context.Context, currentVersion string) (*selfupdate.Info, error) {
+				if tt.selfUpdateErr != nil {
+					return nil, tt.selfUpdateErr
+				}
+
+				if tt.selfUpdateInfo == nil {
+					return nil, nil
+				}
+
+				return &selfupdate.Info{
+					CurrentVersion: tt.selfUpdateInfo.CurrentVersion,
+					LatestVersion:  tt.selfUpdateInfo.LatestVersion,
+				}, nil
+			}
+
+			got, err := g.Check(context.Background())
+			if tt.wantErrContains != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErrContains)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, got)
+			assert.Equal(t, tt.wantUpdates, got.AvailableUpdates)
+			assertPackageNames(t, got.Packages, tt.wantPackageNames)
+			assertPackageNewVersions(t, got.Packages, tt.wantNewVersions)
+
+			for _, part := range tt.wantMessageParts {
+				assert.Contains(t, got.Message, part)
+			}
+
+			for modulePath, wantCalls := range tt.wantLatestCallMap {
+				assert.Equal(t, wantCalls, latestCalls[modulePath], "modulePath=%s", modulePath)
+			}
+		})
+	}
 }
 
 func TestGoUpdater_Update_DryRun(t *testing.T) {
@@ -151,12 +343,10 @@ func TestGoUpdater_Update_DryRun(t *testing.T) {
 	})
 
 	t.Run("更新対象あり", func(t *testing.T) {
-		g := &GoUpdater{
-			targets: []string{
-				"golang.org/x/tools/gopls@latest",
-				"github.com/fatih/gomodifytags",
-			},
-		}
+		g := newTestGoUpdater([]string{
+			"golang.org/x/tools/gopls@latest",
+			"github.com/fatih/gomodifytags",
+		}, nil)
 
 		got, err := g.Update(context.Background(), UpdateOptions{DryRun: true})
 		require.NoError(t, err)
@@ -170,6 +360,122 @@ func TestGoUpdater_Update_DryRun(t *testing.T) {
 		assert.Equal(t, "gomodifytags", got.Packages[1].Name)
 		assert.Equal(t, "@latest", got.Packages[1].NewVersion)
 	})
+}
+
+func TestGoUpdater_Update_InstallsOnlyPlannedTargets(t *testing.T) {
+	g := newTestGoUpdater([]string{
+		"github.com/foo/latest@latest",
+		"github.com/foo/update@latest",
+		"github.com/foo/missing",
+		"github.com/foo/pinned@v1.2.3",
+		"github.com/scottlz0310/dsx/cmd/dsx@latest",
+	}, []GoBinaryInfo{
+		{PackagePath: "github.com/foo/latest", ModulePath: "github.com/foo/latestmod", InstalledVersion: "v1.0.0"},
+		{PackagePath: "github.com/foo/update", ModulePath: "github.com/foo/updatemod", InstalledVersion: "v1.0.0"},
+	})
+
+	g.currentVersion = "v0.4.1"
+	g.latestModuleVersion = func(_ context.Context, modulePath string) (string, error) {
+		switch modulePath {
+		case "github.com/foo/latestmod":
+			return "v1.0.0", nil
+		case "github.com/foo/updatemod":
+			return "v1.1.0", nil
+		default:
+			return "", nil
+		}
+	}
+	g.selfUpdateCheck = func(context.Context, string) (*selfupdate.Info, error) {
+		return nil, nil
+	}
+
+	var installed []string
+
+	g.installGoTarget = func(_ context.Context, target string) error {
+		installed = append(installed, target)
+		return nil
+	}
+
+	got, err := g.Update(context.Background(), UpdateOptions{})
+	require.NoError(t, err)
+	require.NotNil(t, got)
+
+	assert.Equal(t, []string{
+		"github.com/foo/update@latest",
+		"github.com/foo/missing@latest",
+		"github.com/foo/pinned@v1.2.3",
+	}, installed)
+	assert.Equal(t, 3, got.UpdatedCount)
+	assert.Equal(t, 0, got.FailedCount)
+	assertPackageNames(t, got.Packages, []string{"update", "missing", "pinned"})
+	assertPackageNewVersions(t, got.Packages, []string{"v1.1.0", "@latest", "v1.2.3"})
+	assert.Contains(t, got.Message, "更新: 3 件")
+	assert.Contains(t, got.Message, "スキップ: 2 件")
+}
+
+func TestGoUpdater_Update_InstallFailure(t *testing.T) {
+	g := newTestGoUpdater([]string{"github.com/foo/bar"}, nil)
+	g.installGoTarget = func(context.Context, string) error {
+		return errors.New("install failed")
+	}
+
+	got, err := g.Update(context.Background(), UpdateOptions{})
+	require.NoError(t, err)
+	require.NotNil(t, got)
+
+	assert.Equal(t, 0, got.UpdatedCount)
+	assert.Equal(t, 1, got.FailedCount)
+	require.Len(t, got.Errors, 1)
+	assert.Contains(t, got.Errors[0].Error(), "install failed")
+	assert.Contains(t, got.Message, "1 件失敗")
+}
+
+func newTestGoUpdater(targets []string, detected []GoBinaryInfo) *GoUpdater {
+	return &GoUpdater{
+		targets: targets,
+		discoverGoBinaries: func(context.Context) (*DiscoverResult, error) {
+			return &DiscoverResult{Detected: detected}, nil
+		},
+		latestModuleVersion: func(context.Context, string) (string, error) {
+			return "", nil
+		},
+		installGoTarget: func(context.Context, string) error {
+			return nil
+		},
+		selfUpdateCheck: func(context.Context, string) (*selfupdate.Info, error) {
+			return nil, nil
+		},
+	}
+}
+
+func assertPackageNames(t *testing.T, packages []PackageInfo, want []string) {
+	t.Helper()
+
+	if want == nil {
+		assert.Empty(t, packages)
+		return
+	}
+
+	require.Len(t, packages, len(want))
+
+	for i, name := range want {
+		assert.Equal(t, name, packages[i].Name)
+	}
+}
+
+func assertPackageNewVersions(t *testing.T, packages []PackageInfo, want []string) {
+	t.Helper()
+
+	if want == nil {
+		assert.Empty(t, packages)
+		return
+	}
+
+	require.Len(t, packages, len(want))
+
+	for i, version := range want {
+		assert.Equal(t, version, packages[i].NewVersion)
+	}
 }
 
 func TestListInstalledGoTools(t *testing.T) {

--- a/internal/updater/go_test.go
+++ b/internal/updater/go_test.go
@@ -430,6 +430,52 @@ func TestGoUpdater_Update_InstallFailure(t *testing.T) {
 	assert.Contains(t, got.Message, "1 件失敗")
 }
 
+func TestParseGoListModuleVersion(t *testing.T) {
+	tests := []struct {
+		name            string
+		output          []byte
+		wantVersion     string
+		wantErrContains []string
+	}{
+		{
+			name:        "Versionをtrimして返す",
+			output:      []byte(`{"Version":" v1.2.3 "}`),
+			wantVersion: "v1.2.3",
+		},
+		{
+			name: "解析エラーは出力内容を含める",
+			output: []byte(`{
+  "Version":`),
+			wantErrContains: []string{
+				"go list -m -json の解析に失敗",
+				`"Version":`,
+			},
+		},
+		{
+			name:   "空JSONなら空文字列",
+			output: []byte(`{}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseGoListModuleVersion(tt.output)
+			if len(tt.wantErrContains) > 0 {
+				require.Error(t, err)
+
+				for _, part := range tt.wantErrContains {
+					assert.Contains(t, err.Error(), part)
+				}
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantVersion, got)
+		})
+	}
+}
+
 func newTestGoUpdater(targets []string, detected []GoBinaryInfo) *GoUpdater {
 	return &GoUpdater{
 		targets: targets,

--- a/internal/updater/go_test.go
+++ b/internal/updater/go_test.go
@@ -357,6 +357,30 @@ func TestGoUpdater_Check_MalformedTargetDoesNotDiscover(t *testing.T) {
 	assert.Contains(t, err.Error(), "go.targets に不正な target")
 }
 
+func TestGoUpdater_Check_DiscoveryWarning(t *testing.T) {
+	g := &GoUpdater{
+		targets: []string{
+			"github.com/foo/bar@latest",
+			"github.com/scottlz0310/dsx/cmd/dsx@latest",
+		},
+		discoverGoBinaries: func(context.Context) (*DiscoverResult, error) {
+			return nil, errors.New("discover failed")
+		},
+		selfUpdateCheck: func(context.Context, string) (*selfupdate.Info, error) {
+			return nil, nil
+		},
+	}
+
+	got, err := g.Check(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, got)
+
+	assert.Contains(t, got.Message, "dsx 本体を除く @latest target は判定不能")
+	assert.NotContains(t, got.Message, "全 target")
+	assert.Equal(t, 1, got.AvailableUpdates)
+	assertPackageNames(t, got.Packages, []string{"bar"})
+}
+
 func TestGoUpdater_Update_DryRun(t *testing.T) {
 	t.Run("更新対象なし", func(t *testing.T) {
 		g := &GoUpdater{}

--- a/internal/updater/go_test.go
+++ b/internal/updater/go_test.go
@@ -271,6 +271,21 @@ func TestGoUpdater_Check(t *testing.T) {
 				"スキップ: 1 件",
 			},
 		},
+		{
+			name:            "空targetは設定エラー",
+			targets:         []string{"  "},
+			wantErrContains: "go.targets に空の target",
+		},
+		{
+			name:            "package空targetは設定エラー",
+			targets:         []string{"@latest"},
+			wantErrContains: "go.targets に不正な target",
+		},
+		{
+			name:            "version空targetは設定エラー",
+			targets:         []string{"github.com/foo/bar@"},
+			wantErrContains: "go.targets に不正な target",
+		},
 	}
 
 	for _, tt := range tests {
@@ -325,6 +340,21 @@ func TestGoUpdater_Check(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGoUpdater_Check_MalformedTargetDoesNotDiscover(t *testing.T) {
+	g := &GoUpdater{
+		targets: []string{"@latest"},
+		discoverGoBinaries: func(context.Context) (*DiscoverResult, error) {
+			t.Fatal("不正な target は Go バイナリ検出前にエラーにする")
+			return nil, nil
+		},
+	}
+
+	got, err := g.Check(context.Background())
+	require.Error(t, err)
+	assert.Nil(t, got)
+	assert.Contains(t, err.Error(), "go.targets に不正な target")
 }
 
 func TestGoUpdater_Update_DryRun(t *testing.T) {
@@ -413,6 +443,28 @@ func TestGoUpdater_Update_InstallsOnlyPlannedTargets(t *testing.T) {
 	assert.Contains(t, got.Message, "スキップ: 2 件")
 }
 
+func TestGoUpdater_Update_DSXSelfTargetUpdateAvailable(t *testing.T) {
+	g := newTestGoUpdater([]string{"github.com/scottlz0310/dsx/cmd/dsx@latest"}, nil)
+	g.selfUpdateCheck = func(context.Context, string) (*selfupdate.Info, error) {
+		return &selfupdate.Info{
+			CurrentVersion: "v0.4.1",
+			LatestVersion:  "v0.4.2",
+		}, nil
+	}
+
+	installed := false
+	g.installGoTarget = func(context.Context, string) error {
+		installed = true
+		return nil
+	}
+
+	got, err := g.Update(context.Background(), UpdateOptions{CurrentVersion: "v0.4.1"})
+	require.Error(t, err)
+	assert.Nil(t, got)
+	assert.Contains(t, err.Error(), "dsx self-update")
+	assert.False(t, installed)
+}
+
 func TestGoUpdater_Update_InstallFailure(t *testing.T) {
 	g := newTestGoUpdater([]string{"github.com/foo/bar"}, nil)
 	g.installGoTarget = func(context.Context, string) error {
@@ -428,6 +480,82 @@ func TestGoUpdater_Update_InstallFailure(t *testing.T) {
 	require.Len(t, got.Errors, 1)
 	assert.Contains(t, got.Errors[0].Error(), "install failed")
 	assert.Contains(t, got.Message, "1 件失敗")
+}
+
+func TestParseGoTarget(t *testing.T) {
+	tests := []struct {
+		name          string
+		raw           string
+		want          parsedGoTarget
+		wantErrSubstr string
+	}{
+		{
+			name: "version指定なしはlatest比較target",
+			raw:  " github.com/foo/bar ",
+			want: parsedGoTarget{
+				Raw:           "github.com/foo/bar",
+				PackagePath:   "github.com/foo/bar",
+				InstallTarget: "github.com/foo/bar@latest",
+				CompareLatest: true,
+			},
+		},
+		{
+			name: "latest指定あり",
+			raw:  "github.com/foo/bar@latest",
+			want: parsedGoTarget{
+				Raw:           "github.com/foo/bar@latest",
+				PackagePath:   "github.com/foo/bar",
+				Version:       "latest",
+				InstallTarget: "github.com/foo/bar@latest",
+				CompareLatest: true,
+			},
+		},
+		{
+			name: "固定バージョン指定あり",
+			raw:  "github.com/foo/bar@v1.2.3",
+			want: parsedGoTarget{
+				Raw:           "github.com/foo/bar@v1.2.3",
+				PackagePath:   "github.com/foo/bar",
+				Version:       "v1.2.3",
+				InstallTarget: "github.com/foo/bar@v1.2.3",
+				CompareLatest: false,
+			},
+		},
+		{
+			name:          "空文字列はエラー",
+			raw:           "",
+			wantErrSubstr: "go.targets に空の target",
+		},
+		{
+			name:          "空白のみはエラー",
+			raw:           " \t ",
+			wantErrSubstr: "go.targets に空の target",
+		},
+		{
+			name:          "package空はエラー",
+			raw:           "@latest",
+			wantErrSubstr: "go.targets に不正な target",
+		},
+		{
+			name:          "version空はエラー",
+			raw:           "github.com/foo/bar@",
+			wantErrSubstr: "go.targets に不正な target",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseGoTarget(tt.raw)
+			if tt.wantErrSubstr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErrSubstr)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
 }
 
 func TestParseGoListModuleVersion(t *testing.T) {

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -61,6 +61,8 @@ type UpdateOptions struct {
 	DryRun bool
 	// Verbose が true の場合、詳細なログを出力
 	Verbose bool
+	// CurrentVersion は実行中 dsx のバージョンです。dsx 本体を更新対象から除外する判定に使用します。
+	CurrentVersion string
 }
 
 // UpdateResult は更新実行の結果を保持します。

--- a/tasks.md
+++ b/tasks.md
@@ -116,6 +116,23 @@
 
 ---
 
+## Issue #63: Go updater の installed/latest 比較と dsx 本体除外
+
+- [x] Issue #63 本文をコードベースと照合し、既実装・矛盾点・リスクを整理
+- [x] `dsx self-update` の更新判定ロジックを `internal/selfupdate` に分離
+- [x] Go updater で `go version -m` 由来の installed と `go list -m -json <module>@latest` の latest を比較
+- [x] latest 一致時は `go install` をスキップし、判定不能・固定バージョン target は従来通り `go install` 対象にする
+- [x] `github.com/scottlz0310/dsx/cmd/dsx` は Go updater で `go install` せず、更新ありの場合のみ `dsx self-update` 誘導エラーにする
+- [x] table-driven tests を追加（最新版スキップ・更新あり・判定不能・固定バージョン・dsx 本体例外・latest 取得キャッシュ）
+- [x] `CHANGELOG.md` / `README.md` を更新
+- [x] `task check` 通過
+- [x] `task test` 通過
+- [x] `go build ./...` 通過
+- [x] `dsx --help` 表示確認（`go run ./cmd/dsx --help` で現行コードを確認）
+- [x] コミット・push
+
+---
+
 ## Backlog / 改善候補
 
 ### `AutoStash` オプションの修正（設定が機能していないバグ）


### PR DESCRIPTION
## 概要

- Go updater で `go version -m` と `go list -m -json <module>@latest` を使い、`@latest` target の installed/latest を best-effort で比較するようにしました。
- 既に最新版の Go ツールは `go install` せず、判定不能または固定バージョン target は従来通り安全側で `go install` 対象にします。
- `dsx` 本体 target は Go updater では実行せず、最新版なら非エラースキップ、更新ありなら `dsx self-update` を案内するエラーにしました。
- `dsx self-update` の判定ロジックを `internal/selfupdate` に切り出し、Go updater からも同じ基準を使えるようにしました。

## 検証

- `task check`
- `task test`
- `go build ./...`
- `go run ./cmd/dsx --help`
- push 前フック: lint / test 通過

Closes #63
