### PR TITLE
feat(repo): branch-clean サブコマンドを追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 
 - `branch-clean` の UNMERGED 判定を `git branch --no-merged` ベースから `upstream:track` ベースに変更（upstream が gone のローカルブランチのみが UNMERGED 候補となり、未 push commit を含む通常の作業ブランチは候補に含まれない）（PR #66 レビュー対応）
 - `branch-clean` のデフォルト動作を safe-by-default 化（`git branch -d` を使用し、未マージのコミットがあるブランチは KEEP として Skipped に記録）（PR #66 レビュー対応）
-- `git fetch --prune --dry-run` の出力解析を LANG/LC_ALL=C に固定してロケール依存を排除（PR #66 レビュー対応）
+- `git remote prune --dry-run` の出力解析を LANG/LC_ALL=C に固定してロケール依存を排除（PR #66 レビュー対応）
 
 ## [v0.5.0] - 2026-05-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@
   - インタラクティブ（デフォルト）/ `--dry-run` / `--yes` の3モード対応
   - `survey/v2` による MultiSelect UI（MERGED・STALE-REF をデフォルト選択）
   - `--exclude` で除外ブランチを指定可能、`--no-fetch` で事前 fetch をスキップ可能
+  - `--force` フラグを追加（指定時のみ UNMERGED/NO-UPSTREAM を `git branch -D` で強制削除）
+  - インタラクティブモードで MultiSelect 確定後に `[y/N]` 最終確認プロンプトを表示（PR #66 レビュー対応）
+  - 削除エラー時に終了コード非ゼロ（PR #66 レビュー対応）
+
+### Changed
+
+- `branch-clean` の UNMERGED 判定を `git branch --no-merged` ベースから `upstream:track` ベースに変更（upstream が gone のローカルブランチのみが UNMERGED 候補となり、未 push commit を含む通常の作業ブランチは候補に含まれない）（PR #66 レビュー対応）
+- `branch-clean` のデフォルト動作を safe-by-default 化（`git branch -d` を使用し、未マージのコミットがあるブランチは KEEP として Skipped に記録）（PR #66 レビュー対応）
+- `git fetch --prune --dry-run` の出力解析を LANG/LC_ALL=C に固定してロケール依存を排除（PR #66 レビュー対応）
 
 ## [v0.5.0] - 2026-05-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@
 - `branch-clean` の UNMERGED 判定を `git branch --no-merged` ベースから `upstream:track` ベースに変更（upstream が gone のローカルブランチのみが UNMERGED 候補となり、未 push commit を含む通常の作業ブランチは候補に含まれない）（PR #66 レビュー対応）
 - `branch-clean` のデフォルト動作を安全側に変更（`git branch -d` を使用し、未マージのコミットがあるブランチは保持として Skipped に記録）（PR #66 レビュー対応）
 - `git remote prune --dry-run` の出力解析を LANG/LC_ALL=C に固定してロケール依存を排除（PR #66 レビュー対応）
+- `branch-clean` の STALE_REF 削除を `git remote prune <remote>` の一括削除から `git update-ref -d refs/remotes/<remote>/<branch>` の候補単位削除に変更し、ユーザーが選択した STALE_REF だけが削除されるよう挙動を一致させた（PR #66 レビュー対応）
+- `repo branch-clean` CLI ハンドラの到達不能だった分岐（`DeleteBranchCandidates` は常に非 nil の result を返すため `cleanErr != nil` の dead code が存在）を整理し、`cleanResult == nil` 防御パスのみを残して直線化した（PR #66 レビュー対応）
+- `internal/repo` パッケージ内に共通定数 `defaultRemoteName = "origin"` を導入し、3 箇所に散在していたリテラルを置き換え（goconst 警告解消）
 
 ## [v0.5.0] - 2026-05-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 ### Changed
 
 - `branch-clean` の UNMERGED 判定を `git branch --no-merged` ベースから `upstream:track` ベースに変更（upstream が gone のローカルブランチのみが UNMERGED 候補となり、未 push commit を含む通常の作業ブランチは候補に含まれない）（PR #66 レビュー対応）
-- `branch-clean` のデフォルト動作を safe-by-default 化（`git branch -d` を使用し、未マージのコミットがあるブランチは KEEP として Skipped に記録）（PR #66 レビュー対応）
+- `branch-clean` のデフォルト動作を安全側に変更（`git branch -d` を使用し、未マージのコミットがあるブランチは保持として Skipped に記録）（PR #66 レビュー対応）
 - `git remote prune --dry-run` の出力解析を LANG/LC_ALL=C に固定してロケール依存を排除（PR #66 レビュー対応）
 
 ## [v0.5.0] - 2026-05-11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@
 
 ## [Unreleased]
 
+### Added
+
+- `dsx repo branch-clean` サブコマンドを追加（Issue #1）
+  - 4カテゴリ（MERGED / UNMERGED / STALE-REF / NO-UPSTREAM）のブランチを検出
+  - インタラクティブ（デフォルト）/ `--dry-run` / `--yes` の3モード対応
+  - `survey/v2` による MultiSelect UI（MERGED・STALE-REF をデフォルト選択）
+  - `--exclude` で除外ブランチを指定可能、`--no-fetch` で事前 fetch をスキップ可能
+
 ## [v0.5.0] - 2026-05-11
 
 ### Added

--- a/cmd/dsx/repo_branch_clean.go
+++ b/cmd/dsx/repo_branch_clean.go
@@ -148,7 +148,12 @@ func processRepoBranchClean(ctx context.Context, repoPath, displayName string, s
 		return 0, 0, 0, 0, 0
 	}
 
-	toDelete, warnCount := selectBranchesToClean(result, displayName)
+	toDelete, warnCount, selectErr := selectBranchesToClean(result, displayName)
+	if selectErr != nil {
+		fmt.Fprintf(os.Stderr, "  ❌ %s: インタラクティブ選択失敗 (%v)\n", displayName, selectErr)
+
+		return 0, 0, 0, warnCount, 1
+	}
 
 	warnings += warnCount
 
@@ -216,19 +221,21 @@ func printRepoCandidates(result *repomgr.BranchScanResult) {
 
 // selectBranchesToClean はモードに応じてクリーンアップ対象を選択します。
 // 返り値 warnCount は --yes モードで自動削除対象外と判断された件数です（実行失敗ではなくスキップ警告）。
-func selectBranchesToClean(result *repomgr.BranchScanResult, displayName string) (toDelete []repomgr.BranchCandidate, warnCount int) {
+// インタラクティブ選択でエラー（TTY なし・入力エラー等）が発生した場合は呼び出し元に伝播し、
+// 呼び出し元で error カウントに反映できるようにします。
+func selectBranchesToClean(result *repomgr.BranchScanResult, displayName string) (toDelete []repomgr.BranchCandidate, warnCount int, err error) {
 	if repoBranchCleanYes {
-		return collectAutoTargets(result.Candidates, displayName)
+		auto, warns := collectAutoTargets(result.Candidates, displayName)
+
+		return auto, warns, nil
 	}
 
 	selected, interactiveErr := askBranchSelection(result)
 	if interactiveErr != nil {
-		fmt.Fprintf(os.Stderr, "  ⚠️  %s: インタラクティブ選択失敗 (%v)\n", displayName, interactiveErr)
-
-		return nil, 0
+		return nil, 0, fmt.Errorf("%s: インタラクティブ選択失敗: %w", displayName, interactiveErr)
 	}
 
-	return selected, 0
+	return selected, 0, nil
 }
 
 // confirmBranchDeletion はインタラクティブモードで削除実行前の最終確認 [y/N] を行います。

--- a/cmd/dsx/repo_branch_clean.go
+++ b/cmd/dsx/repo_branch_clean.go
@@ -15,6 +15,7 @@ import (
 var (
 	repoBranchCleanDryRun  bool
 	repoBranchCleanYes     bool
+	repoBranchCleanForce   bool
 	repoBranchCleanNoFetch bool
 	repoBranchCleanExclude []string
 )
@@ -26,14 +27,18 @@ var repoBranchCleanCmd = &cobra.Command{
 
 カテゴリ:
   [MERGED]      デフォルトブランチにマージ済みのローカルブランチ（安全削除）
-  [UNMERGED]    未マージのローカルブランチ（最終コミット日時付き）
+  [UNMERGED]    upstream が gone（リモート側で削除済み）のローカルブランチ
   [STALE-REF]   リモートに存在しないリモートトラッキング参照（prune で除去）
   [NO-UPSTREAM] アップストリームが未設定のローカルブランチ
 
 実行モード:
-  デフォルト  インタラクティブに削除するブランチを選択します
+  デフォルト  インタラクティブに削除するブランチを選択します（最終確認 [y/N] あり）
   --dry-run   候補を表示するのみで実際の操作は行いません
-  --yes       MERGED と STALE-REF を自動削除します（UNMERGED・NO-UPSTREAM は表示のみ）`,
+  --yes       MERGED と STALE-REF を自動削除します（UNMERGED・NO-UPSTREAM は表示のみ）
+
+安全性:
+  デフォルトでは git branch -d（安全削除）を使い、未マージのコミットがあるブランチは KEEP されます。
+  リスクを許容して強制削除する場合は --force を指定してください（UNMERGED/NO-UPSTREAM が git branch -D で削除されます）。`,
 	RunE: runRepoBranchClean,
 }
 
@@ -43,6 +48,7 @@ func init() {
 	repoBranchCleanCmd.Flags().StringVar(&repoRootOverride, "root", "", "対象のルートディレクトリ（指定時は設定を上書き）")
 	repoBranchCleanCmd.Flags().BoolVarP(&repoBranchCleanDryRun, "dry-run", "n", false, "候補を表示するのみ（実際の操作は行わない）")
 	repoBranchCleanCmd.Flags().BoolVarP(&repoBranchCleanYes, "yes", "y", false, "安全なブランチ（MERGED・STALE-REF）を自動削除")
+	repoBranchCleanCmd.Flags().BoolVar(&repoBranchCleanForce, "force", false, "UNMERGED/NO-UPSTREAM を git branch -D で強制削除（未push commit を失う可能性あり）")
 	repoBranchCleanCmd.Flags().BoolVar(&repoBranchCleanNoFetch, "no-fetch", false, "スキャン前の git fetch をスキップ")
 	repoBranchCleanCmd.Flags().StringArrayVar(&repoBranchCleanExclude, "exclude", nil, "除外するブランチ名（複数指定可）")
 }
@@ -95,55 +101,79 @@ func runRepoBranchClean(cmd *cobra.Command, _ []string) error {
 
 	totalDeleted := 0
 	totalPruned := 0
+	totalSkipped := 0
+	totalWarnings := 0
 	totalErrors := 0
 
 	for _, repoPath := range repoPaths {
-		displayName := buildRepoJobDisplayName(repoPath, root)
-		deleted, pruned, errors := processRepoBranchClean(ctx, repoPath, displayName, scanOpts)
+		displayName := buildRepoJobDisplayName(root, repoPath)
+		deleted, pruned, skipped, warnings, errors := processRepoBranchClean(ctx, repoPath, displayName, scanOpts)
 
 		totalDeleted += deleted
 		totalPruned += pruned
+		totalSkipped += skipped
+		totalWarnings += warnings
 		totalErrors += errors
 	}
 
-	printSummary(totalDeleted, totalPruned, totalErrors, repoBranchCleanDryRun)
+	printSummary(totalDeleted, totalPruned, totalSkipped, totalWarnings, totalErrors, repoBranchCleanDryRun)
+
+	if !repoBranchCleanDryRun && totalErrors > 0 {
+		return fmt.Errorf("ブランチクリーンアップで %d 件のエラーが発生しました", totalErrors)
+	}
 
 	return nil
 }
 
-// processRepoBranchClean は単一リポジトリのブランチクリーンアップを実行し、削除・プルーン・エラーの件数を返します。
-func processRepoBranchClean(ctx context.Context, repoPath, displayName string, scanOpts repomgr.BranchScanOptions) (deleted, pruned, errors int) {
+// processRepoBranchClean は単一リポジトリのブランチクリーンアップを実行し、削除・プルーン・スキップ・警告・エラーの件数を返します。
+// skipped は -d 失敗等で安全のため KEEP したブランチ件数（情報レベル）、warnings は --yes モードの対象外スキップ件数（注意レベル）。
+func processRepoBranchClean(ctx context.Context, repoPath, displayName string, scanOpts repomgr.BranchScanOptions) (deleted, pruned, skipped, warnings, errors int) {
 	result, scanErr := repomgr.ScanBranches(ctx, repoPath, scanOpts)
 	if scanErr != nil {
 		fmt.Fprintf(os.Stderr, "  ⚠️  %s: スキャン失敗 (%v)\n", displayName, scanErr)
 
-		return 0, 0, 1
+		return 0, 0, 0, 0, 1
 	}
 
 	if len(result.Candidates) == 0 {
 		fmt.Printf("  ✅ %s: クリーンアップ不要\n", displayName)
 
-		return 0, 0, 0
+		return 0, 0, 0, 0, 0
 	}
 
 	fmt.Printf("  📁 %s (ブランチ: %s)\n", displayName, result.DefaultBranch)
 	printRepoCandidates(result)
 
 	if repoBranchCleanDryRun {
-		return 0, 0, 0
+		return 0, 0, 0, 0, 0
 	}
 
 	toDelete, warnCount := selectBranchesToClean(result, displayName)
 
-	errors += warnCount
+	warnings += warnCount
 
 	if len(toDelete) == 0 {
 		fmt.Printf("  ⏭️  %s: 選択なし（スキップ）\n\n", displayName)
 
-		return 0, 0, errors
+		return 0, 0, 0, warnings, 0
 	}
 
-	cleanResult, cleanErr := repomgr.DeleteBranchCandidates(ctx, repoPath, toDelete, false)
+	if !repoBranchCleanYes {
+		confirmed, confirmErr := confirmBranchDeletion(displayName, toDelete)
+		if confirmErr != nil {
+			fmt.Fprintf(os.Stderr, "  ⚠️  %s: 確認プロンプト失敗 (%v)\n", displayName, confirmErr)
+
+			return 0, 0, 0, warnings, 1
+		}
+
+		if !confirmed {
+			fmt.Printf("  ⏭️  %s: 確認がキャンセルされました（スキップ）\n\n", displayName)
+
+			return 0, 0, 0, warnings, 0
+		}
+	}
+
+	cleanResult, cleanErr := repomgr.DeleteBranchCandidates(ctx, repoPath, toDelete, false, repoBranchCleanForce)
 	if cleanResult != nil {
 		for _, errItem := range cleanResult.Errors {
 			fmt.Fprintf(os.Stderr, "  ⚠️  %s: %v\n", displayName, errItem)
@@ -151,16 +181,16 @@ func processRepoBranchClean(ctx context.Context, repoPath, displayName string, s
 
 		printCleanResult(displayName, cleanResult)
 
-		return len(cleanResult.Deleted), len(cleanResult.Pruned), errors + len(cleanResult.Errors)
+		return len(cleanResult.Deleted), len(cleanResult.Pruned), len(cleanResult.Skipped), warnings, len(cleanResult.Errors)
 	}
 
 	if cleanErr != nil {
 		fmt.Fprintf(os.Stderr, "  ❌ %s: クリーンアップ失敗 (%v)\n", displayName, cleanErr)
 
-		return 0, 0, errors + 1
+		return 0, 0, 0, warnings, 1
 	}
 
-	return 0, 0, errors
+	return 0, 0, 0, warnings, 0
 }
 
 // printRepoCandidates は単一リポジトリのブランチ候補一覧を表示します。
@@ -195,10 +225,33 @@ func selectBranchesToClean(result *repomgr.BranchScanResult, displayName string)
 	if interactiveErr != nil {
 		fmt.Fprintf(os.Stderr, "  ⚠️  %s: インタラクティブ選択失敗 (%v)\n", displayName, interactiveErr)
 
-		return nil, 1
+		return nil, 0
 	}
 
 	return selected, 0
+}
+
+// confirmBranchDeletion はインタラクティブモードで削除実行前の最終確認 [y/N] を行います。
+// Issue #1 の受け入れ条件「Proceed? [y/N] で y|Y のみ実行」を満たします。
+func confirmBranchDeletion(displayName string, toDelete []repomgr.BranchCandidate) (bool, error) {
+	names := make([]string, len(toDelete))
+	for i, c := range toDelete {
+		names[i] = c.Name
+	}
+
+	fmt.Printf("  ❓ %s: 以下 %d 件を削除します: %s\n", displayName, len(toDelete), strings.Join(names, ", "))
+
+	confirm := false
+	prompt := &survey.Confirm{
+		Message: "実行しますか?",
+		Default: false,
+	}
+
+	if err := survey.AskOne(prompt, &confirm); err != nil {
+		return false, err
+	}
+
+	return confirm, nil
 }
 
 // collectAutoTargets は --yes モードで自動削除対象を収集し、安全でない候補については警告します。
@@ -315,11 +368,15 @@ func printCleanResult(displayName string, result *repomgr.BranchCleanResult) {
 		fmt.Printf("  ✂️  %s: プルーン完了: %s\n", displayName, strings.Join(names, ", "))
 	}
 
+	for _, skip := range result.Skipped {
+		fmt.Printf("  ⏭️  %s: %s をスキップしました（%s）\n", displayName, skip.Candidate.Name, skip.Reason)
+	}
+
 	fmt.Println()
 }
 
 // printSummary は全リポジトリ処理後のサマリーを表示します。
-func printSummary(deleted, pruned, errors int, dryRun bool) {
+func printSummary(deleted, pruned, skipped, warnings, errors int, dryRun bool) {
 	fmt.Println("─────────────────────────────────────────")
 
 	if dryRun {
@@ -329,6 +386,14 @@ func printSummary(deleted, pruned, errors int, dryRun bool) {
 	}
 
 	fmt.Printf("✅ クリーンアップ完了: ブランチ削除 %d件, プルーン %d件", deleted, pruned)
+
+	if skipped > 0 {
+		fmt.Printf(", スキップ %d件", skipped)
+	}
+
+	if warnings > 0 {
+		fmt.Printf(", 警告 %d件", warnings)
+	}
 
 	if errors > 0 {
 		fmt.Printf(", エラー %d件", errors)

--- a/cmd/dsx/repo_branch_clean.go
+++ b/cmd/dsx/repo_branch_clean.go
@@ -37,7 +37,7 @@ var repoBranchCleanCmd = &cobra.Command{
   --yes       MERGED と STALE-REF を自動削除します（UNMERGED・NO-UPSTREAM は表示のみ）
 
 安全性:
-  デフォルトでは git branch -d（安全削除）を使い、未マージのコミットがあるブランチは KEEP されます。
+  デフォルトでは git branch -d（安全削除）を使い、未マージのコミットがあるブランチは削除されずに保持されます。
   リスクを許容して強制削除する場合は --force を指定してください（UNMERGED/NO-UPSTREAM が git branch -D で削除されます）。`,
 	RunE: runRepoBranchClean,
 }
@@ -126,7 +126,7 @@ func runRepoBranchClean(cmd *cobra.Command, _ []string) error {
 }
 
 // processRepoBranchClean は単一リポジトリのブランチクリーンアップを実行し、削除・プルーン・スキップ・警告・エラーの件数を返します。
-// skipped は -d 失敗等で安全のため KEEP したブランチ件数（情報レベル）、warnings は --yes モードの対象外スキップ件数（注意レベル）。
+// skipped は -d 失敗等で安全のため保持したブランチ件数（情報レベル）、warnings は --yes モードの対象外スキップ件数（注意レベル）。
 func processRepoBranchClean(ctx context.Context, repoPath, displayName string, scanOpts repomgr.BranchScanOptions) (deleted, pruned, skipped, warnings, errors int) {
 	result, scanErr := repomgr.ScanBranches(ctx, repoPath, scanOpts)
 	if scanErr != nil {
@@ -178,7 +178,7 @@ func processRepoBranchClean(ctx context.Context, repoPath, displayName string, s
 		}
 	}
 
-	cleanResult, cleanErr := repomgr.DeleteBranchCandidates(ctx, repoPath, toDelete, false, repoBranchCleanForce)
+	cleanResult, cleanErr := repomgr.DeleteBranchCandidates(ctx, repoPath, toDelete, false, repoBranchCleanForce, result.DefaultBranch)
 	if cleanResult != nil {
 		for _, errItem := range cleanResult.Errors {
 			fmt.Fprintf(os.Stderr, "  ⚠️  %s: %v\n", displayName, errItem)

--- a/cmd/dsx/repo_branch_clean.go
+++ b/cmd/dsx/repo_branch_clean.go
@@ -1,0 +1,338 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	survey "github.com/AlecAivazis/survey/v2"
+	repomgr "github.com/scottlz0310/dsx/internal/repo"
+	"github.com/spf13/cobra"
+)
+
+var (
+	repoBranchCleanDryRun  bool
+	repoBranchCleanYes     bool
+	repoBranchCleanNoFetch bool
+	repoBranchCleanExclude []string
+)
+
+var repoBranchCleanCmd = &cobra.Command{
+	Use:   "branch-clean",
+	Short: "不要なブランチを検出してクリーンアップします",
+	Long: `全リポジトリのブランチを4つのカテゴリで検出してクリーンアップします。
+
+カテゴリ:
+  [MERGED]      デフォルトブランチにマージ済みのローカルブランチ（安全削除）
+  [UNMERGED]    未マージのローカルブランチ（最終コミット日時付き）
+  [STALE-REF]   リモートに存在しないリモートトラッキング参照（prune で除去）
+  [NO-UPSTREAM] アップストリームが未設定のローカルブランチ
+
+実行モード:
+  デフォルト  インタラクティブに削除するブランチを選択します
+  --dry-run   候補を表示するのみで実際の操作は行いません
+  --yes       MERGED と STALE-REF を自動削除します（UNMERGED・NO-UPSTREAM は表示のみ）`,
+	RunE: runRepoBranchClean,
+}
+
+func init() {
+	repoCmd.AddCommand(repoBranchCleanCmd)
+
+	repoBranchCleanCmd.Flags().StringVar(&repoRootOverride, "root", "", "対象のルートディレクトリ（指定時は設定を上書き）")
+	repoBranchCleanCmd.Flags().BoolVarP(&repoBranchCleanDryRun, "dry-run", "n", false, "候補を表示するのみ（実際の操作は行わない）")
+	repoBranchCleanCmd.Flags().BoolVarP(&repoBranchCleanYes, "yes", "y", false, "安全なブランチ（MERGED・STALE-REF）を自動削除")
+	repoBranchCleanCmd.Flags().BoolVar(&repoBranchCleanNoFetch, "no-fetch", false, "スキャン前の git fetch をスキップ")
+	repoBranchCleanCmd.Flags().StringArrayVar(&repoBranchCleanExclude, "exclude", nil, "除外するブランチ名（複数指定可）")
+}
+
+func runRepoBranchClean(cmd *cobra.Command, _ []string) error {
+	cfg, configExists, configPath := loadRepoConfig()
+
+	root := cfg.Repo.Root
+	if cmd.Flags().Changed("root") {
+		root = repoRootOverride
+	}
+
+	timeout := 10 * time.Minute
+	if parsed, parseErr := time.ParseDuration(cfg.Control.Timeout); parseErr == nil {
+		timeout = parsed
+	}
+
+	baseCtx := cmd.Context()
+	if baseCtx == nil {
+		baseCtx = context.Background()
+	}
+
+	ctx, cancel := context.WithTimeout(baseCtx, timeout)
+	defer cancel()
+
+	repoPaths, err := repomgr.Discover(root)
+	if err != nil {
+		return wrapRepoRootError(err, root, cmd.Flags().Changed("root"), configExists, configPath)
+	}
+
+	if len(repoPaths) == 0 {
+		fmt.Printf("📝 対象のリポジトリが見つかりませんでした: %s\n", root)
+
+		return nil
+	}
+
+	scanOpts := repomgr.BranchScanOptions{
+		Fetch:           !repoBranchCleanNoFetch,
+		ExcludeBranches: repoBranchCleanExclude,
+	}
+
+	modeLabel := "インタラクティブモード"
+	if repoBranchCleanDryRun {
+		modeLabel = "ドライランモード"
+	} else if repoBranchCleanYes {
+		modeLabel = "自動実行モード"
+	}
+
+	fmt.Printf("🔍 ブランチスキャン開始 (%s, リポジトリ数: %d)\n\n", modeLabel, len(repoPaths))
+
+	totalDeleted := 0
+	totalPruned := 0
+	totalErrors := 0
+
+	for _, repoPath := range repoPaths {
+		displayName := buildRepoJobDisplayName(repoPath, root)
+		deleted, pruned, errors := processRepoBranchClean(ctx, repoPath, displayName, scanOpts)
+
+		totalDeleted += deleted
+		totalPruned += pruned
+		totalErrors += errors
+	}
+
+	printSummary(totalDeleted, totalPruned, totalErrors, repoBranchCleanDryRun)
+
+	return nil
+}
+
+// processRepoBranchClean は単一リポジトリのブランチクリーンアップを実行し、削除・プルーン・エラーの件数を返します。
+func processRepoBranchClean(ctx context.Context, repoPath, displayName string, scanOpts repomgr.BranchScanOptions) (deleted, pruned, errors int) {
+	result, scanErr := repomgr.ScanBranches(ctx, repoPath, scanOpts)
+	if scanErr != nil {
+		fmt.Fprintf(os.Stderr, "  ⚠️  %s: スキャン失敗 (%v)\n", displayName, scanErr)
+
+		return 0, 0, 1
+	}
+
+	if len(result.Candidates) == 0 {
+		fmt.Printf("  ✅ %s: クリーンアップ不要\n", displayName)
+
+		return 0, 0, 0
+	}
+
+	fmt.Printf("  📁 %s (ブランチ: %s)\n", displayName, result.DefaultBranch)
+	printRepoCandidates(result)
+
+	if repoBranchCleanDryRun {
+		return 0, 0, 0
+	}
+
+	toDelete, warnCount := selectBranchesToClean(result, displayName)
+
+	errors += warnCount
+
+	if len(toDelete) == 0 {
+		fmt.Printf("  ⏭️  %s: 選択なし（スキップ）\n\n", displayName)
+
+		return 0, 0, errors
+	}
+
+	cleanResult, cleanErr := repomgr.DeleteBranchCandidates(ctx, repoPath, toDelete, false)
+	if cleanResult != nil {
+		for _, errItem := range cleanResult.Errors {
+			fmt.Fprintf(os.Stderr, "  ⚠️  %s: %v\n", displayName, errItem)
+		}
+
+		printCleanResult(displayName, cleanResult)
+
+		return len(cleanResult.Deleted), len(cleanResult.Pruned), errors + len(cleanResult.Errors)
+	}
+
+	if cleanErr != nil {
+		fmt.Fprintf(os.Stderr, "  ❌ %s: クリーンアップ失敗 (%v)\n", displayName, cleanErr)
+
+		return 0, 0, errors + 1
+	}
+
+	return 0, 0, errors
+}
+
+// printRepoCandidates は単一リポジトリのブランチ候補一覧を表示します。
+func printRepoCandidates(result *repomgr.BranchScanResult) {
+	for _, c := range result.Candidates {
+		label := repomgr.CategoryLabel(c.Category)
+
+		age := ""
+		if c.Age != "" {
+			age = fmt.Sprintf("  (%s)", c.Age)
+		}
+
+		autoMark := ""
+		if repomgr.IsSafeToAutoDelete(c.Category) {
+			autoMark = " ✔"
+		}
+
+		fmt.Printf("    %s %s%s%s\n", label, c.Name, age, autoMark)
+	}
+
+	fmt.Println()
+}
+
+// selectBranchesToClean はモードに応じてクリーンアップ対象を選択します。
+// 返り値 warnCount は --yes モードで自動削除対象外と判断された件数です（実行失敗ではなくスキップ警告）。
+func selectBranchesToClean(result *repomgr.BranchScanResult, displayName string) (toDelete []repomgr.BranchCandidate, warnCount int) {
+	if repoBranchCleanYes {
+		return collectAutoTargets(result.Candidates, displayName)
+	}
+
+	selected, interactiveErr := askBranchSelection(result)
+	if interactiveErr != nil {
+		fmt.Fprintf(os.Stderr, "  ⚠️  %s: インタラクティブ選択失敗 (%v)\n", displayName, interactiveErr)
+
+		return nil, 1
+	}
+
+	return selected, 0
+}
+
+// collectAutoTargets は --yes モードで自動削除対象を収集し、安全でない候補については警告します。
+func collectAutoTargets(candidates []repomgr.BranchCandidate, displayName string) (toDelete []repomgr.BranchCandidate, warnCount int) {
+	for _, c := range candidates {
+		if repomgr.IsSafeToAutoDelete(c.Category) {
+			toDelete = append(toDelete, c)
+
+			continue
+		}
+
+		label := repomgr.CategoryLabel(c.Category)
+
+		age := ""
+		if c.Age != "" {
+			age = fmt.Sprintf(" (%s)", c.Age)
+		}
+
+		fmt.Printf("  ⚠️  %s: %s %s%s は自動削除対象外です（手動で確認してください）\n",
+			displayName, label, c.Name, age)
+
+		warnCount++
+	}
+
+	return toDelete, warnCount
+}
+
+// askBranchSelection はインタラクティブモードでブランチ選択を行います。
+// MERGED と STALE_REF をデフォルトで選択済みにします。
+func askBranchSelection(result *repomgr.BranchScanResult) ([]repomgr.BranchCandidate, error) {
+	type option struct {
+		label     string
+		candidate repomgr.BranchCandidate
+	}
+
+	options := make([]option, 0, len(result.Candidates))
+
+	var defaultSelected []string
+
+	for _, c := range result.Candidates {
+		label := buildOptionLabel(c)
+
+		options = append(options, option{label: label, candidate: c})
+
+		if repomgr.IsSafeToAutoDelete(c.Category) {
+			defaultSelected = append(defaultSelected, label)
+		}
+	}
+
+	optionLabels := make([]string, len(options))
+	labelToCandidate := make(map[string]repomgr.BranchCandidate, len(options))
+
+	for i, o := range options {
+		optionLabels[i] = o.label
+		labelToCandidate[o.label] = o.candidate
+	}
+
+	var selectedLabels []string
+
+	prompt := &survey.MultiSelect{
+		Message: "削除するブランチを選択してください（スペースで選択、Enterで確定）",
+		Options: optionLabels,
+		Default: defaultSelected,
+	}
+
+	if err := survey.AskOne(prompt, &selectedLabels); err != nil {
+		return nil, err
+	}
+
+	selected := make([]repomgr.BranchCandidate, 0, len(selectedLabels))
+
+	for _, label := range selectedLabels {
+		if c, ok := labelToCandidate[label]; ok {
+			selected = append(selected, c)
+		}
+	}
+
+	return selected, nil
+}
+
+// buildOptionLabel はブランチ候補の選択肢ラベル文字列を構築します。
+func buildOptionLabel(c repomgr.BranchCandidate) string {
+	parts := []string{
+		repomgr.CategoryLabel(c.Category),
+		c.Name,
+	}
+
+	if c.Age != "" {
+		parts = append(parts, fmt.Sprintf("(%s)", c.Age))
+	}
+
+	return strings.Join(parts, " ")
+}
+
+// printCleanResult はクリーンアップ結果を表示します。
+func printCleanResult(displayName string, result *repomgr.BranchCleanResult) {
+	if len(result.Deleted) > 0 {
+		names := make([]string, len(result.Deleted))
+
+		for i, c := range result.Deleted {
+			names[i] = c.Name
+		}
+
+		fmt.Printf("  🗑️  %s: ブランチ削除: %s\n", displayName, strings.Join(names, ", "))
+	}
+
+	if len(result.Pruned) > 0 {
+		names := make([]string, len(result.Pruned))
+
+		for i, c := range result.Pruned {
+			names[i] = c.Name
+		}
+
+		fmt.Printf("  ✂️  %s: プルーン完了: %s\n", displayName, strings.Join(names, ", "))
+	}
+
+	fmt.Println()
+}
+
+// printSummary は全リポジトリ処理後のサマリーを表示します。
+func printSummary(deleted, pruned, errors int, dryRun bool) {
+	fmt.Println("─────────────────────────────────────────")
+
+	if dryRun {
+		fmt.Println("📋 ドライラン完了（実際の操作は行いませんでした）")
+
+		return
+	}
+
+	fmt.Printf("✅ クリーンアップ完了: ブランチ削除 %d件, プルーン %d件", deleted, pruned)
+
+	if errors > 0 {
+		fmt.Printf(", エラー %d件", errors)
+	}
+
+	fmt.Println()
+}

--- a/cmd/dsx/repo_branch_clean.go
+++ b/cmd/dsx/repo_branch_clean.go
@@ -179,23 +179,25 @@ func processRepoBranchClean(ctx context.Context, repoPath, displayName string, s
 	}
 
 	cleanResult, cleanErr := repomgr.DeleteBranchCandidates(ctx, repoPath, toDelete, false, repoBranchCleanForce, result.DefaultBranch)
-	if cleanResult != nil {
-		for _, errItem := range cleanResult.Errors {
-			fmt.Fprintf(os.Stderr, "  ⚠️  %s: %v\n", displayName, errItem)
-		}
-
-		printCleanResult(displayName, cleanResult)
-
-		return len(cleanResult.Deleted), len(cleanResult.Pruned), len(cleanResult.Skipped), warnings, len(cleanResult.Errors)
-	}
-
-	if cleanErr != nil {
+	if cleanResult == nil {
+		// DeleteBranchCandidates は現契約では常に non-nil な result を返しますが、
+		// 将来の API 変更で nil が返るケースに備えて防御的に処理します。
 		fmt.Fprintf(os.Stderr, "  ❌ %s: クリーンアップ失敗 (%v)\n", displayName, cleanErr)
 
 		return 0, 0, 0, warnings, 1
 	}
 
-	return 0, 0, 0, warnings, 0
+	// cleanErr は cleanResult.Errors を errors.Join したサマリーであり、
+	// 個別エラーは下のループで全件表示するため明示的に破棄します。
+	_ = cleanErr
+
+	for _, errItem := range cleanResult.Errors {
+		fmt.Fprintf(os.Stderr, "  ⚠️  %s: %v\n", displayName, errItem)
+	}
+
+	printCleanResult(displayName, cleanResult)
+
+	return len(cleanResult.Deleted), len(cleanResult.Pruned), len(cleanResult.Skipped), warnings, len(cleanResult.Errors)
 }
 
 // printRepoCandidates は単一リポジトリのブランチ候補一覧を表示します。

--- a/internal/repo/branch_clean.go
+++ b/internal/repo/branch_clean.go
@@ -1,0 +1,111 @@
+package repo
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+)
+
+// BranchCleanResult は単一リポジトリのブランチクリーンアップ実行結果です。
+type BranchCleanResult struct {
+	RepoPath string
+	// Deleted は削除が完了したローカルブランチ（dryRun 時は削除予定のブランチ）
+	Deleted []BranchCandidate
+	// Pruned は prune が完了したリモートトラッキング参照（dryRun 時は prune 予定の参照）
+	Pruned []BranchCandidate
+	// Errors は各操作で発生したエラーのリスト
+	Errors []error
+}
+
+// DeleteBranchCandidates は選択されたブランチ候補を削除・プルーンします。
+//
+// 削除フラグ:
+//   - MERGED:       git branch -d（安全削除）
+//   - UNMERGED:     git branch -D（強制削除）
+//   - NO_UPSTREAM:  git branch -D（強制削除）
+//   - STALE_REF:    git remote prune <remote>（リモートごとに1回まとめて実行）
+//
+// dryRun が true の場合は実際の操作は行わず、結果に候補を記録するのみです。
+func DeleteBranchCandidates(ctx context.Context, repoPath string, candidates []BranchCandidate, dryRun bool) (*BranchCleanResult, error) {
+	cleanPath := filepath.Clean(repoPath)
+	result := &BranchCleanResult{RepoPath: cleanPath}
+
+	staleByRemote, localBranches := separateBranchCandidates(candidates)
+
+	for _, c := range localBranches {
+		deleteLocalBranch(ctx, cleanPath, c, dryRun, result)
+	}
+
+	for remote, refs := range staleByRemote {
+		pruneRemoteRefs(ctx, cleanPath, remote, refs, dryRun, result)
+	}
+
+	if len(result.Errors) > 0 {
+		return result, fmt.Errorf("%d 件の操作に失敗しました", len(result.Errors))
+	}
+
+	return result, nil
+}
+
+// separateBranchCandidates は候補をローカルブランチとリモートごとのスタレ参照に分離します。
+func separateBranchCandidates(candidates []BranchCandidate) (staleByRemote map[string][]BranchCandidate, localBranches []BranchCandidate) {
+	staleByRemote = make(map[string][]BranchCandidate)
+
+	for _, c := range candidates {
+		if c.Category != BranchCategoryStaleRef {
+			localBranches = append(localBranches, c)
+
+			continue
+		}
+
+		remote := c.Remote
+		if remote == "" {
+			remote = "origin"
+		}
+
+		staleByRemote[remote] = append(staleByRemote[remote], c)
+	}
+
+	return staleByRemote, localBranches
+}
+
+// deleteLocalBranch は1つのローカルブランチを削除します。
+func deleteLocalBranch(ctx context.Context, cleanPath string, c BranchCandidate, dryRun bool, result *BranchCleanResult) {
+	flag := "-d"
+	if c.Category == BranchCategoryUnmerged || c.Category == BranchCategoryNoUpstream {
+		flag = "-D"
+	}
+
+	if dryRun {
+		result.Deleted = append(result.Deleted, c)
+
+		return
+	}
+
+	if err := runGitCommand(ctx, cleanPath, "branch", flag, c.Name); err != nil {
+		result.Errors = append(result.Errors, fmt.Errorf("%s の削除に失敗: %w", c.Name, err))
+
+		return
+	}
+
+	result.Deleted = append(result.Deleted, c)
+}
+
+// pruneRemoteRefs は指定リモートのスタレ参照をまとめて prune します。
+func pruneRemoteRefs(ctx context.Context, cleanPath, remote string, refs []BranchCandidate, dryRun bool, result *BranchCleanResult) {
+	if dryRun {
+		result.Pruned = append(result.Pruned, refs...)
+
+		return
+	}
+
+	if err := runGitCommand(ctx, cleanPath, "remote", "prune", remote); err != nil {
+		for _, ref := range refs {
+			result.Errors = append(result.Errors, fmt.Errorf("%s のプルーンに失敗: %w", ref.Name, err))
+		}
+
+		return
+	}
+
+	result.Pruned = append(result.Pruned, refs...)
+}

--- a/internal/repo/branch_clean.go
+++ b/internal/repo/branch_clean.go
@@ -14,7 +14,7 @@ type BranchCleanResult struct {
 	Deleted []BranchCandidate
 	// Pruned は prune が完了したリモートトラッキング参照（dryRun 時は prune 予定の参照）
 	Pruned []BranchCandidate
-	// Skipped は未 push commit 等のため安全に削除できず KEEP したブランチ（警告レベル、エラーではない）
+	// Skipped は未 push commit 等のため安全に削除できず保持したブランチ（警告レベル、エラーではない）
 	Skipped []BranchSkip
 	// Errors は各操作で発生したエラーのリスト
 	Errors []error
@@ -29,21 +29,24 @@ type BranchSkip struct {
 // DeleteBranchCandidates は選択されたブランチ候補を削除・プルーンします。
 //
 // 削除フラグ:
-//   - MERGED:       git branch -d（安全削除）
-//   - UNMERGED:     git branch -d（safe by default; force=true の場合は -D で強制削除）
-//   - NO_UPSTREAM:  git branch -d（safe by default; force=true の場合は -D で強制削除）
+//   - MERGED:       git branch -d（安全削除）。-d が HEAD 依存で失敗した場合は
+//     git merge-base --is-ancestor でデフォルトブランチへのマージを再確認し、
+//     マージ済みであれば git branch -D で削除します。
+//   - UNMERGED:     デフォルトは安全側（git branch -d）。--force 指定時のみ git branch -D で強制削除
+//   - NO_UPSTREAM:  デフォルトは安全側（git branch -d）。--force 指定時のみ git branch -D で強制削除
 //   - STALE_REF:    git remote prune <remote>（リモートごとに1回まとめて実行）
 //
-// -d 失敗時はエラーではなく Skipped に記録します（未 push commit を含むブランチを誤って失う事故を防ぐため）。
+// UNMERGED/NO_UPSTREAM の -d 失敗時はエラーではなく Skipped に記録します
+// （未 push commit を含むブランチを誤って失う事故を防ぐため）。
 // dryRun が true の場合は実際の操作は行わず、結果に候補を記録するのみです。
-func DeleteBranchCandidates(ctx context.Context, repoPath string, candidates []BranchCandidate, dryRun, force bool) (*BranchCleanResult, error) {
+func DeleteBranchCandidates(ctx context.Context, repoPath string, candidates []BranchCandidate, dryRun, force bool, defaultBranch string) (*BranchCleanResult, error) {
 	cleanPath := filepath.Clean(repoPath)
 	result := &BranchCleanResult{RepoPath: cleanPath}
 
 	staleByRemote, localBranches := separateBranchCandidates(candidates)
 
 	for _, c := range localBranches {
-		deleteLocalBranch(ctx, cleanPath, c, dryRun, force, result)
+		deleteLocalBranch(ctx, cleanPath, c, dryRun, force, defaultBranch, result)
 	}
 
 	for remote, refs := range staleByRemote {
@@ -82,10 +85,15 @@ func separateBranchCandidates(candidates []BranchCandidate) (staleByRemote map[s
 }
 
 // deleteLocalBranch は1つのローカルブランチを削除します。
-// safe by default: UNMERGED/NO_UPSTREAM でも force=false のときは `-d`（安全削除）を使い、
+// 安全性方針（デフォルト）: UNMERGED/NO_UPSTREAM でも --force 未指定のときは `-d`（安全削除）を使い、
 // 失敗時は Skipped に記録します（未 push commit を含むブランチを誤って失う事故を防ぐため）。
-// force=true のときのみ `-D`（強制削除）を使います。
-func deleteLocalBranch(ctx context.Context, cleanPath string, c BranchCandidate, dryRun, force bool, result *BranchCleanResult) {
+// --force 指定時のみ `-D`（強制削除）を使います。
+//
+// MERGED 救済: `-d` は「現在の HEAD にマージ済みか」を判定するため、ユーザーが
+// デフォルトブランチ以外を checkout している状態だと、デフォルトブランチへマージ済みでも
+// `-d` が失敗します。この場合は git merge-base --is-ancestor でデフォルトブランチへの
+// マージを再確認し、確認できれば `-D` で削除します（判定基準と削除条件を揃える）。
+func deleteLocalBranch(ctx context.Context, cleanPath string, c BranchCandidate, dryRun, force bool, defaultBranch string, result *BranchCleanResult) {
 	flag := "-d"
 	if force && (c.Category == BranchCategoryUnmerged || c.Category == BranchCategoryNoUpstream) {
 		flag = "-D"
@@ -98,7 +106,17 @@ func deleteLocalBranch(ctx context.Context, cleanPath string, c BranchCandidate,
 	}
 
 	if err := runGitCommand(ctx, cleanPath, "branch", flag, c.Name); err != nil {
-		// safe by default モードでは -d が失敗しても通常想定（例: --force で再実行を促す）
+		if flag == "-d" && c.Category == BranchCategoryMerged && defaultBranch != "" {
+			if mergedIntoDefault(ctx, cleanPath, defaultBranch, c.Name) {
+				if forceErr := runGitCommand(ctx, cleanPath, "branch", "-D", c.Name); forceErr == nil {
+					result.Deleted = append(result.Deleted, c)
+
+					return
+				}
+			}
+		}
+
+		// 安全モードでは UNMERGED/NO_UPSTREAM の -d 失敗は想定内（--force で再実行を促す）
 		if flag == "-d" && (c.Category == BranchCategoryUnmerged || c.Category == BranchCategoryNoUpstream) {
 			result.Skipped = append(result.Skipped, BranchSkip{
 				Candidate: c,
@@ -114,6 +132,19 @@ func deleteLocalBranch(ctx context.Context, cleanPath string, c BranchCandidate,
 	}
 
 	result.Deleted = append(result.Deleted, c)
+}
+
+// mergedIntoDefault はブランチがデフォルトブランチへマージ済みかどうかを
+// git merge-base --is-ancestor <branch> <defaultBranch> で確認します。
+// 確認できない場合（コマンド失敗など）は false を返します。
+func mergedIntoDefault(ctx context.Context, cleanPath, defaultBranch, branch string) bool {
+	if defaultBranch == "" || branch == "" {
+		return false
+	}
+
+	err := runGitCommand(ctx, cleanPath, "merge-base", "--is-ancestor", branch, defaultBranch)
+
+	return err == nil
 }
 
 // pruneRemoteRefs は指定リモートのスタレ参照をまとめて prune します。

--- a/internal/repo/branch_clean.go
+++ b/internal/repo/branch_clean.go
@@ -13,27 +13,36 @@ type BranchCleanResult struct {
 	Deleted []BranchCandidate
 	// Pruned は prune が完了したリモートトラッキング参照（dryRun 時は prune 予定の参照）
 	Pruned []BranchCandidate
+	// Skipped は未 push commit 等のため安全に削除できず KEEP したブランチ（警告レベル、エラーではない）
+	Skipped []BranchSkip
 	// Errors は各操作で発生したエラーのリスト
 	Errors []error
+}
+
+// BranchSkip は削除をスキップしたブランチと理由を表します。
+type BranchSkip struct {
+	Candidate BranchCandidate
+	Reason    string
 }
 
 // DeleteBranchCandidates は選択されたブランチ候補を削除・プルーンします。
 //
 // 削除フラグ:
 //   - MERGED:       git branch -d（安全削除）
-//   - UNMERGED:     git branch -D（強制削除）
-//   - NO_UPSTREAM:  git branch -D（強制削除）
+//   - UNMERGED:     git branch -d（safe by default; force=true の場合は -D で強制削除）
+//   - NO_UPSTREAM:  git branch -d（safe by default; force=true の場合は -D で強制削除）
 //   - STALE_REF:    git remote prune <remote>（リモートごとに1回まとめて実行）
 //
+// -d 失敗時はエラーではなく Skipped に記録します（未 push commit を含むブランチを誤って失う事故を防ぐため）。
 // dryRun が true の場合は実際の操作は行わず、結果に候補を記録するのみです。
-func DeleteBranchCandidates(ctx context.Context, repoPath string, candidates []BranchCandidate, dryRun bool) (*BranchCleanResult, error) {
+func DeleteBranchCandidates(ctx context.Context, repoPath string, candidates []BranchCandidate, dryRun, force bool) (*BranchCleanResult, error) {
 	cleanPath := filepath.Clean(repoPath)
 	result := &BranchCleanResult{RepoPath: cleanPath}
 
 	staleByRemote, localBranches := separateBranchCandidates(candidates)
 
 	for _, c := range localBranches {
-		deleteLocalBranch(ctx, cleanPath, c, dryRun, result)
+		deleteLocalBranch(ctx, cleanPath, c, dryRun, force, result)
 	}
 
 	for remote, refs := range staleByRemote {
@@ -70,9 +79,12 @@ func separateBranchCandidates(candidates []BranchCandidate) (staleByRemote map[s
 }
 
 // deleteLocalBranch は1つのローカルブランチを削除します。
-func deleteLocalBranch(ctx context.Context, cleanPath string, c BranchCandidate, dryRun bool, result *BranchCleanResult) {
+// safe by default: UNMERGED/NO_UPSTREAM でも force=false のときは `-d`（安全削除）を使い、
+// 失敗時は Skipped に記録します（未 push commit を含むブランチを誤って失う事故を防ぐため）。
+// force=true のときのみ `-D`（強制削除）を使います。
+func deleteLocalBranch(ctx context.Context, cleanPath string, c BranchCandidate, dryRun, force bool, result *BranchCleanResult) {
 	flag := "-d"
-	if c.Category == BranchCategoryUnmerged || c.Category == BranchCategoryNoUpstream {
+	if force && (c.Category == BranchCategoryUnmerged || c.Category == BranchCategoryNoUpstream) {
 		flag = "-D"
 	}
 
@@ -83,6 +95,16 @@ func deleteLocalBranch(ctx context.Context, cleanPath string, c BranchCandidate,
 	}
 
 	if err := runGitCommand(ctx, cleanPath, "branch", flag, c.Name); err != nil {
+		// safe by default モードでは -d が失敗しても通常想定（例: --force で再実行を促す）
+		if flag == "-d" && (c.Category == BranchCategoryUnmerged || c.Category == BranchCategoryNoUpstream) {
+			result.Skipped = append(result.Skipped, BranchSkip{
+				Candidate: c,
+				Reason:    "未 push commit がある可能性があるため安全削除に失敗しました（強制削除するには --force を指定）",
+			})
+
+			return
+		}
+
 		result.Errors = append(result.Errors, fmt.Errorf("%s の削除に失敗: %w", c.Name, err))
 
 		return

--- a/internal/repo/branch_clean.go
+++ b/internal/repo/branch_clean.go
@@ -34,7 +34,7 @@ type BranchSkip struct {
 //     マージ済みであれば git branch -D で削除します。
 //   - UNMERGED:     デフォルトは安全側（git branch -d）。--force 指定時のみ git branch -D で強制削除
 //   - NO_UPSTREAM:  デフォルトは安全側（git branch -d）。--force 指定時のみ git branch -D で強制削除
-//   - STALE_REF:    git remote prune <remote>（リモートごとに1回まとめて実行）
+//   - STALE_REF:    git update-ref -d refs/remotes/<remote>/<branch>（候補単位で個別削除）
 //
 // UNMERGED/NO_UPSTREAM の -d 失敗時はエラーではなく Skipped に記録します
 // （未 push commit を含むブランチを誤って失う事故を防ぐため）。
@@ -49,8 +49,8 @@ func DeleteBranchCandidates(ctx context.Context, repoPath string, candidates []B
 		deleteLocalBranch(ctx, cleanPath, c, dryRun, force, defaultBranch, result)
 	}
 
-	for remote, refs := range staleByRemote {
-		pruneRemoteRefs(ctx, cleanPath, remote, refs, dryRun, result)
+	for _, refs := range staleByRemote {
+		pruneRemoteRefs(ctx, cleanPath, refs, dryRun, result)
 	}
 
 	if len(result.Errors) > 0 {
@@ -75,7 +75,7 @@ func separateBranchCandidates(candidates []BranchCandidate) (staleByRemote map[s
 
 		remote := c.Remote
 		if remote == "" {
-			remote = "origin"
+			remote = defaultRemoteName
 		}
 
 		staleByRemote[remote] = append(staleByRemote[remote], c)
@@ -147,21 +147,26 @@ func mergedIntoDefault(ctx context.Context, cleanPath, defaultBranch, branch str
 	return err == nil
 }
 
-// pruneRemoteRefs は指定リモートのスタレ参照をまとめて prune します。
-func pruneRemoteRefs(ctx context.Context, cleanPath, remote string, refs []BranchCandidate, dryRun bool, result *BranchCleanResult) {
-	if dryRun {
-		result.Pruned = append(result.Pruned, refs...)
+// pruneRemoteRefs は STALE_REF 候補を個別に削除します。
+// 以前は git remote prune <remote> でリモート単位の一括 prune を行っていましたが、
+// 「ユーザーが選択した候補のみ削除する」という UI 上の挙動と整合させるため、
+// 候補ごとに git update-ref -d refs/remotes/<remote>/<branch> を実行する仕様に変更しました。
+// これにより、選択を外した STALE_REF が誤って prune されることがなくなります。
+func pruneRemoteRefs(ctx context.Context, cleanPath string, refs []BranchCandidate, dryRun bool, result *BranchCleanResult) {
+	for _, ref := range refs {
+		if dryRun {
+			result.Pruned = append(result.Pruned, ref)
 
-		return
-	}
-
-	if err := runGitCommand(ctx, cleanPath, "remote", "prune", remote); err != nil {
-		for _, ref := range refs {
-			result.Errors = append(result.Errors, fmt.Errorf("%s のプルーンに失敗: %w", ref.Name, err))
+			continue
 		}
 
-		return
-	}
+		fullRef := "refs/remotes/" + ref.Name
+		if err := runGitCommand(ctx, cleanPath, "update-ref", "-d", fullRef); err != nil {
+			result.Errors = append(result.Errors, fmt.Errorf("%s のプルーンに失敗: %w", ref.Name, err))
 
-	result.Pruned = append(result.Pruned, refs...)
+			continue
+		}
+
+		result.Pruned = append(result.Pruned, ref)
+	}
 }

--- a/internal/repo/branch_clean.go
+++ b/internal/repo/branch_clean.go
@@ -2,6 +2,7 @@ package repo
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
 )
@@ -50,7 +51,9 @@ func DeleteBranchCandidates(ctx context.Context, repoPath string, candidates []B
 	}
 
 	if len(result.Errors) > 0 {
-		return result, fmt.Errorf("%d 件の操作に失敗しました", len(result.Errors))
+		joined := errors.Join(result.Errors...)
+
+		return result, fmt.Errorf("%d 件の操作に失敗しました: %w", len(result.Errors), joined)
 	}
 
 	return result, nil

--- a/internal/repo/branch_scan.go
+++ b/internal/repo/branch_scan.go
@@ -1,0 +1,283 @@
+package repo
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+// BranchCategory はブランチクリーンアップ候補のカテゴリです。
+type BranchCategory string
+
+const (
+	// BranchCategoryMerged はデフォルトブランチにマージ済みのローカルブランチです。安全に削除できます。
+	BranchCategoryMerged BranchCategory = "merged"
+	// BranchCategoryUnmerged はデフォルトブランチに未マージのローカルブランチです。強制削除が必要です。
+	BranchCategoryUnmerged BranchCategory = "unmerged"
+	// BranchCategoryStaleRef はリモートに存在しないリモートトラッキング参照です。prune で除去できます。
+	BranchCategoryStaleRef BranchCategory = "stale_ref"
+	// BranchCategoryNoUpstream はアップストリームが設定されていないローカルブランチです。強制削除が必要です。
+	BranchCategoryNoUpstream BranchCategory = "no_upstream"
+)
+
+// BranchCandidate はブランチクリーンアップ候補を表します。
+type BranchCandidate struct {
+	// Name はブランチ名、または STALE_REF の場合は "<remote>/<branch>" 形式
+	Name string
+	// Category はブランチのカテゴリ
+	Category BranchCategory
+	// Age は最終コミットからの経過時間（BranchCategoryUnmerged のみ設定）
+	Age string
+	// Remote はリモート名（BranchCategoryStaleRef のみ設定）
+	Remote string
+}
+
+// BranchScanResult は単一リポジトリのブランチスキャン結果です。
+type BranchScanResult struct {
+	RepoPath      string
+	DefaultBranch string
+	CurrentBranch string
+	Candidates    []BranchCandidate
+}
+
+// BranchScanOptions はブランチスキャンのオプションです。
+type BranchScanOptions struct {
+	// Fetch が true の場合、スキャン前に git fetch --prune を実行します。
+	Fetch           bool
+	ExcludeBranches []string
+}
+
+// ScanBranches は単一リポジトリのブランチクリーンアップ候補を収集します。
+//
+// 収集するカテゴリ:
+//   - merged:      デフォルトブランチにマージ済みローカルブランチ（安全に削除可能）
+//   - unmerged:    未マージのローカルブランチ（最終コミット経過時間付き）
+//   - stale_ref:   リモートに存在しないリモートトラッキング参照（prune で除去）
+//   - no_upstream: アップストリームが未設定のローカルブランチ
+func ScanBranches(ctx context.Context, repoPath string, opts BranchScanOptions) (*BranchScanResult, error) {
+	cleanPath := filepath.Clean(repoPath)
+	result := &BranchScanResult{RepoPath: cleanPath}
+
+	if opts.Fetch {
+		if err := runGitCommand(ctx, cleanPath, "fetch", "--quiet", "--prune"); err != nil {
+			return result, fmt.Errorf("fetch に失敗: %w", err)
+		}
+	}
+
+	defaultInfo, err := DetectDefaultBranch(ctx, cleanPath)
+	if err != nil {
+		return result, fmt.Errorf("デフォルトブランチの検出に失敗: %w", err)
+	}
+
+	result.DefaultBranch = defaultInfo.Branch
+
+	currentBranch, err := getCurrentBranchName(ctx, cleanPath)
+	if err != nil {
+		return result, fmt.Errorf("現在のブランチの取得に失敗: %w", err)
+	}
+
+	result.CurrentBranch = currentBranch
+
+	excluded := buildExcludedBranchSet(currentBranch, defaultInfo.Branch, opts.ExcludeBranches)
+
+	// ローカルのデフォルトブランチ名で判定することで、git push 前のローカルマージも検出できる
+	mergedBranches, err := listMergedLocalBranches(ctx, cleanPath, defaultInfo.Branch)
+	if err != nil {
+		return result, fmt.Errorf("マージ済みブランチの取得に失敗: %w", err)
+	}
+
+	mergedSet := make(map[string]struct{}, len(mergedBranches))
+
+	for _, b := range mergedBranches {
+		if isExcludedBranch(excluded, b) {
+			continue
+		}
+
+		mergedSet[b] = struct{}{}
+
+		result.Candidates = append(result.Candidates, BranchCandidate{
+			Name:     b,
+			Category: BranchCategoryMerged,
+		})
+	}
+
+	unmerged, err := scanUnmergedBranches(ctx, cleanPath, defaultInfo.Branch, excluded, mergedSet)
+	if err != nil {
+		return result, fmt.Errorf("未マージブランチの取得に失敗: %w", err)
+	}
+
+	result.Candidates = append(result.Candidates, unmerged...)
+
+	noUpstream, err := scanNoUpstreamBranches(ctx, cleanPath, excluded, mergedSet)
+	if err != nil {
+		return result, fmt.Errorf("アップストリーム未設定ブランチの取得に失敗: %w", err)
+	}
+
+	result.Candidates = append(result.Candidates, noUpstream...)
+
+	// スタレ参照の検出は非必須（ネットワーク不可など失敗する場合はスキップ）
+	staleRefs, err := scanStaleRemoteRefs(ctx, cleanPath, defaultInfo.Remote)
+	if err == nil {
+		result.Candidates = append(result.Candidates, staleRefs...)
+	}
+
+	return result, nil
+}
+
+// CategoryLabel はカテゴリの固定幅表示ラベルを返します。
+func CategoryLabel(c BranchCategory) string {
+	switch c {
+	case BranchCategoryMerged:
+		return "[MERGED]"
+	case BranchCategoryUnmerged:
+		return "[UNMERGED]"
+	case BranchCategoryStaleRef:
+		return "[STALE-REF]"
+	case BranchCategoryNoUpstream:
+		return "[NO-UPSTREAM]"
+	default:
+		return "[UNKNOWN]"
+	}
+}
+
+// IsSafeToAutoDelete は --yes モードで確認なしに自動削除できるカテゴリかどうかを返します。
+// MERGED と STALE_REF のみ自動削除安全とみなします。
+func IsSafeToAutoDelete(c BranchCategory) bool {
+	return c == BranchCategoryMerged || c == BranchCategoryStaleRef
+}
+
+// scanUnmergedBranches はデフォルトブランチに未マージのローカルブランチを収集します。
+// フォーマット文字列に %00（NUL バイト）を使い、相対日時のスペースを安全に扱います。
+func scanUnmergedBranches(ctx context.Context, repoPath, defaultRef string, excluded, mergedSet map[string]struct{}) ([]BranchCandidate, error) {
+	output, err := runGitCommandOutput(ctx, repoPath,
+		"for-each-ref",
+		"--format=%(refname:short)%00%(committerdate:relative)",
+		"--no-merged="+defaultRef,
+		"refs/heads",
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	var candidates []BranchCandidate
+
+	for _, line := range strings.Split(strings.TrimSpace(string(output)), "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+
+		parts := strings.SplitN(line, "\x00", 2)
+
+		branch := strings.TrimSpace(parts[0])
+		if branch == "" {
+			continue
+		}
+
+		age := ""
+		if len(parts) == 2 {
+			age = strings.TrimSpace(parts[1])
+		}
+
+		if isExcludedBranch(excluded, branch) {
+			continue
+		}
+
+		if _, isMerged := mergedSet[branch]; isMerged {
+			continue
+		}
+
+		candidates = append(candidates, BranchCandidate{
+			Name:     branch,
+			Category: BranchCategoryUnmerged,
+			Age:      age,
+		})
+	}
+
+	return candidates, nil
+}
+
+// scanNoUpstreamBranches はアップストリームが未設定のローカルブランチを収集します。
+// 既に MERGED に分類されたブランチは除外して重複を防ぎます。
+func scanNoUpstreamBranches(ctx context.Context, repoPath string, excluded, mergedSet map[string]struct{}) ([]BranchCandidate, error) {
+	output, err := runGitCommandOutput(ctx, repoPath,
+		"for-each-ref",
+		"--format=%(refname:short)%00%(upstream:short)",
+		"refs/heads",
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	var candidates []BranchCandidate
+
+	for _, line := range strings.Split(strings.TrimSpace(string(output)), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+
+		parts := strings.SplitN(line, "\x00", 2)
+
+		branch := strings.TrimSpace(parts[0])
+		if branch == "" {
+			continue
+		}
+
+		// アップストリームが設定されている場合は2番目のフィールドが空でない
+		if len(parts) == 2 && strings.TrimSpace(parts[1]) != "" {
+			continue
+		}
+
+		if isExcludedBranch(excluded, branch) {
+			continue
+		}
+
+		if _, isMerged := mergedSet[branch]; isMerged {
+			continue
+		}
+
+		candidates = append(candidates, BranchCandidate{
+			Name:     branch,
+			Category: BranchCategoryNoUpstream,
+		})
+	}
+
+	return candidates, nil
+}
+
+// scanStaleRemoteRefs は git remote prune --dry-run で除去対象となるリモートトラッキング参照を収集します。
+func scanStaleRemoteRefs(ctx context.Context, repoPath, remote string) ([]BranchCandidate, error) {
+	if remote == "" {
+		remote = "origin"
+	}
+
+	output, err := runGitCommandOutput(ctx, repoPath, "remote", "prune", remote, "--dry-run")
+	if err != nil {
+		return nil, err
+	}
+
+	const wouldPruneMarker = "[would prune]"
+
+	var candidates []BranchCandidate
+
+	for _, line := range strings.Split(string(output), "\n") {
+		idx := strings.Index(line, wouldPruneMarker)
+		if idx < 0 {
+			continue
+		}
+
+		ref := strings.TrimSpace(line[idx+len(wouldPruneMarker):])
+		if ref == "" {
+			continue
+		}
+
+		candidates = append(candidates, BranchCandidate{
+			Name:     ref,
+			Category: BranchCategoryStaleRef,
+			Remote:   remote,
+		})
+	}
+
+	return candidates, nil
+}

--- a/internal/repo/branch_scan.go
+++ b/internal/repo/branch_scan.go
@@ -109,7 +109,12 @@ func ScanBranches(ctx context.Context, repoPath string, opts BranchScanOptions) 
 
 	result.Candidates = append(result.Candidates, unmerged...)
 
-	noUpstream, err := scanNoUpstreamBranches(ctx, cleanPath, excluded, mergedSet)
+	unmergedSet := make(map[string]struct{}, len(unmerged))
+	for _, c := range unmerged {
+		unmergedSet[c.Name] = struct{}{}
+	}
+
+	noUpstream, err := scanNoUpstreamBranches(ctx, cleanPath, excluded, mergedSet, unmergedSet)
 	if err != nil {
 		return result, fmt.Errorf("アップストリーム未設定ブランチの取得に失敗: %w", err)
 	}
@@ -198,8 +203,8 @@ func scanUnmergedBranches(ctx context.Context, repoPath, defaultRef string, excl
 }
 
 // scanNoUpstreamBranches はアップストリームが未設定のローカルブランチを収集します。
-// 既に MERGED に分類されたブランチは除外して重複を防ぎます。
-func scanNoUpstreamBranches(ctx context.Context, repoPath string, excluded, mergedSet map[string]struct{}) ([]BranchCandidate, error) {
+// 既に MERGED または UNMERGED に分類されたブランチは除外して重複を防ぎます。
+func scanNoUpstreamBranches(ctx context.Context, repoPath string, excluded, mergedSet, unmergedSet map[string]struct{}) ([]BranchCandidate, error) {
 	output, err := runGitCommandOutput(ctx, repoPath,
 		"for-each-ref",
 		"--format=%(refname:short)%00%(upstream:short)",
@@ -234,6 +239,10 @@ func scanNoUpstreamBranches(ctx context.Context, repoPath string, excluded, merg
 		}
 
 		if _, isMerged := mergedSet[branch]; isMerged {
+			continue
+		}
+
+		if _, isUnmerged := unmergedSet[branch]; isUnmerged {
 			continue
 		}
 

--- a/internal/repo/branch_scan.go
+++ b/internal/repo/branch_scan.go
@@ -13,11 +13,11 @@ type BranchCategory string
 const (
 	// BranchCategoryMerged はデフォルトブランチにマージ済みのローカルブランチです。安全に削除できます。
 	BranchCategoryMerged BranchCategory = "merged"
-	// BranchCategoryUnmerged はデフォルトブランチに未マージのローカルブランチです。強制削除が必要です。
+	// BranchCategoryUnmerged はデフォルトブランチに未マージのローカルブランチです（upstream が gone のもののみ候補化）。デフォルトでは git branch -d で安全削除を試み、失敗時は Skipped 扱いとし、`--force` 指定時のみ -D で強制削除します。
 	BranchCategoryUnmerged BranchCategory = "unmerged"
 	// BranchCategoryStaleRef はリモートに存在しないリモートトラッキング参照です。prune で除去できます。
 	BranchCategoryStaleRef BranchCategory = "stale_ref"
-	// BranchCategoryNoUpstream はアップストリームが設定されていないローカルブランチです。強制削除が必要です。
+	// BranchCategoryNoUpstream はアップストリームが設定されていないローカルブランチです。デフォルトでは git branch -d で安全削除を試み、失敗時は Skipped 扱いとし、`--force` 指定時のみ -D で強制削除します。
 	BranchCategoryNoUpstream BranchCategory = "no_upstream"
 )
 

--- a/internal/repo/branch_scan.go
+++ b/internal/repo/branch_scan.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"strconv"
 	"strings"
+	"time"
 )
 
 // BranchCategory はブランチクリーンアップ候補のカテゴリです。
@@ -154,7 +156,7 @@ func IsSafeToAutoDelete(c BranchCategory) bool {
 
 // scanUnmergedBranches は upstream が gone（リモート側で削除済み）のローカルブランチを収集します。
 //
-// Issue #1 の Must 要件「未 push commit があるブランチは絶対 KEEP」「upstream gone のみ削除対象」を満たすため、
+// Issue #1 の Must 要件「未 push commit があるブランチは絶対に保持」「upstream gone のみ削除対象」を満たすため、
 // 通常の作業ブランチ（upstream 生存）や未 push commit を含むブランチ（ahead）は候補に含めません。
 // upstream:track の出力解析はロケール依存のため LANG/LC_ALL=C を強制します。
 func scanUnmergedBranches(ctx context.Context, repoPath, defaultRef string, excluded, mergedSet map[string]struct{}) ([]BranchCandidate, error) {
@@ -162,7 +164,7 @@ func scanUnmergedBranches(ctx context.Context, repoPath, defaultRef string, excl
 
 	output, err := runGitCommandOutputLocaleC(ctx, repoPath,
 		"for-each-ref",
-		"--format=%(refname:short)%00%(upstream:short)%00%(upstream:track)%00%(committerdate:relative)",
+		"--format=%(refname:short)%00%(upstream:short)%00%(upstream:track)%00%(committerdate:unix)",
 		"refs/heads",
 	)
 	if err != nil {
@@ -228,7 +230,7 @@ func parseUnmergedBranchLine(line string, excluded, mergedSet map[string]struct{
 
 	age := ""
 	if len(parts) >= 4 {
-		age = strings.TrimSpace(parts[3])
+		age = formatRelativeAgeJP(strings.TrimSpace(parts[3]), time.Now())
 	}
 
 	return BranchCandidate{
@@ -236,6 +238,42 @@ func parseUnmergedBranchLine(line string, excluded, mergedSet map[string]struct{
 		Category: BranchCategoryUnmerged,
 		Age:      age,
 	}, true
+}
+
+// formatRelativeAgeJP は committerdate:unix 形式の文字列を日本語の相対表現に整形します。
+// ロケール非依存にするため git の relative 文字列ではなく Go 側で算出します。
+// 解析失敗時は空文字列を返します。
+func formatRelativeAgeJP(unixStr string, now time.Time) string {
+	if unixStr == "" {
+		return ""
+	}
+
+	sec, err := strconv.ParseInt(unixStr, 10, 64)
+	if err != nil {
+		return ""
+	}
+
+	diff := now.Sub(time.Unix(sec, 0))
+	if diff < 0 {
+		diff = 0
+	}
+
+	switch {
+	case diff < time.Minute:
+		return "たった今"
+	case diff < time.Hour:
+		return fmt.Sprintf("%d分前", int(diff/time.Minute))
+	case diff < 24*time.Hour:
+		return fmt.Sprintf("%d時間前", int(diff/time.Hour))
+	case diff < 7*24*time.Hour:
+		return fmt.Sprintf("%d日前", int(diff/(24*time.Hour)))
+	case diff < 30*24*time.Hour:
+		return fmt.Sprintf("%d週間前", int(diff/(7*24*time.Hour)))
+	case diff < 365*24*time.Hour:
+		return fmt.Sprintf("%dヶ月前", int(diff/(30*24*time.Hour)))
+	default:
+		return fmt.Sprintf("%d年前", int(diff/(365*24*time.Hour)))
+	}
 }
 
 // scanNoUpstreamBranches はアップストリームが未設定のローカルブランチを収集します。

--- a/internal/repo/branch_scan.go
+++ b/internal/repo/branch_scan.go
@@ -333,7 +333,7 @@ func scanNoUpstreamBranches(ctx context.Context, repoPath string, excluded, merg
 // 出力中の "[would prune]" マーカーはロケール依存のため LANG/LC_ALL=C を強制します。
 func scanStaleRemoteRefs(ctx context.Context, repoPath, remote string) ([]BranchCandidate, error) {
 	if remote == "" {
-		remote = "origin"
+		remote = defaultRemoteName
 	}
 
 	output, err := runGitCommandOutputLocaleC(ctx, repoPath, "remote", "prune", remote, "--dry-run")

--- a/internal/repo/branch_scan.go
+++ b/internal/repo/branch_scan.go
@@ -152,13 +152,17 @@ func IsSafeToAutoDelete(c BranchCategory) bool {
 	return c == BranchCategoryMerged || c == BranchCategoryStaleRef
 }
 
-// scanUnmergedBranches はデフォルトブランチに未マージのローカルブランチを収集します。
-// フォーマット文字列に %00（NUL バイト）を使い、相対日時のスペースを安全に扱います。
+// scanUnmergedBranches は upstream が gone（リモート側で削除済み）のローカルブランチを収集します。
+//
+// Issue #1 の Must 要件「未 push commit があるブランチは絶対 KEEP」「upstream gone のみ削除対象」を満たすため、
+// 通常の作業ブランチ（upstream 生存）や未 push commit を含むブランチ（ahead）は候補に含めません。
+// upstream:track の出力解析はロケール依存のため LANG/LC_ALL=C を強制します。
 func scanUnmergedBranches(ctx context.Context, repoPath, defaultRef string, excluded, mergedSet map[string]struct{}) ([]BranchCandidate, error) {
-	output, err := runGitCommandOutput(ctx, repoPath,
+	_ = defaultRef // 互換のため引数は保持（カテゴリ判定は upstream:track に切り替え）
+
+	output, err := runGitCommandOutputLocaleC(ctx, repoPath,
 		"for-each-ref",
-		"--format=%(refname:short)%00%(committerdate:relative)",
-		"--no-merged="+defaultRef,
+		"--format=%(refname:short)%00%(upstream:short)%00%(upstream:track)%00%(committerdate:relative)",
 		"refs/heads",
 	)
 	if err != nil {
@@ -168,38 +172,70 @@ func scanUnmergedBranches(ctx context.Context, repoPath, defaultRef string, excl
 	var candidates []BranchCandidate
 
 	for _, line := range strings.Split(strings.TrimSpace(string(output)), "\n") {
-		if strings.TrimSpace(line) == "" {
+		c, ok := parseUnmergedBranchLine(line, excluded, mergedSet)
+		if !ok {
 			continue
 		}
 
-		parts := strings.SplitN(line, "\x00", 2)
-
-		branch := strings.TrimSpace(parts[0])
-		if branch == "" {
-			continue
-		}
-
-		age := ""
-		if len(parts) == 2 {
-			age = strings.TrimSpace(parts[1])
-		}
-
-		if isExcludedBranch(excluded, branch) {
-			continue
-		}
-
-		if _, isMerged := mergedSet[branch]; isMerged {
-			continue
-		}
-
-		candidates = append(candidates, BranchCandidate{
-			Name:     branch,
-			Category: BranchCategoryUnmerged,
-			Age:      age,
-		})
+		candidates = append(candidates, c)
 	}
 
 	return candidates, nil
+}
+
+// parseUnmergedBranchLine は for-each-ref の1行を解析し、UNMERGED 候補に該当するか判定します。
+// 該当しない（ヘッダ空行・除外・既にMERGED・upstream未設定・ahead・gone以外）場合は ok=false を返します。
+func parseUnmergedBranchLine(line string, excluded, mergedSet map[string]struct{}) (BranchCandidate, bool) {
+	if strings.TrimSpace(line) == "" {
+		return BranchCandidate{}, false
+	}
+
+	parts := strings.SplitN(line, "\x00", 4)
+
+	branch := strings.TrimSpace(parts[0])
+	if branch == "" {
+		return BranchCandidate{}, false
+	}
+
+	if isExcludedBranch(excluded, branch) {
+		return BranchCandidate{}, false
+	}
+
+	if _, isMerged := mergedSet[branch]; isMerged {
+		return BranchCandidate{}, false
+	}
+
+	upstream := ""
+	if len(parts) >= 2 {
+		upstream = strings.TrimSpace(parts[1])
+	}
+
+	// upstream 未設定は NO_UPSTREAM 側で扱う
+	if upstream == "" {
+		return BranchCandidate{}, false
+	}
+
+	track := ""
+	if len(parts) >= 3 {
+		track = strings.TrimSpace(parts[2])
+	}
+
+	// 未 push commit を含むブランチ（ahead）は絶対に候補に入れない（Issue #1 Must）
+	// upstream gone のみ削除候補に入れる
+	if strings.Contains(track, "ahead") || !strings.Contains(track, "gone") {
+		return BranchCandidate{}, false
+	}
+
+	age := ""
+	if len(parts) >= 4 {
+		age = strings.TrimSpace(parts[3])
+	}
+
+	return BranchCandidate{
+		Name:     branch,
+		Category: BranchCategoryUnmerged,
+		Age:      age,
+	}, true
 }
 
 // scanNoUpstreamBranches はアップストリームが未設定のローカルブランチを収集します。
@@ -256,12 +292,13 @@ func scanNoUpstreamBranches(ctx context.Context, repoPath string, excluded, merg
 }
 
 // scanStaleRemoteRefs は git remote prune --dry-run で除去対象となるリモートトラッキング参照を収集します。
+// 出力中の "[would prune]" マーカーはロケール依存のため LANG/LC_ALL=C を強制します。
 func scanStaleRemoteRefs(ctx context.Context, repoPath, remote string) ([]BranchCandidate, error) {
 	if remote == "" {
 		remote = "origin"
 	}
 
-	output, err := runGitCommandOutput(ctx, repoPath, "remote", "prune", remote, "--dry-run")
+	output, err := runGitCommandOutputLocaleC(ctx, repoPath, "remote", "prune", remote, "--dry-run")
 	if err != nil {
 		return nil, err
 	}

--- a/internal/repo/branch_scan_test.go
+++ b/internal/repo/branch_scan_test.go
@@ -1,0 +1,674 @@
+package repo
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestScanBranches_Merged(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		setupRepo    func(t *testing.T) (repoPath, featureBranch string)
+		wantInMerged bool
+		wantBranch   string
+	}{
+		{
+			name: "マージ済みブランチが MERGED カテゴリに含まれる",
+			setupRepo: func(t *testing.T) (string, string) {
+				t.Helper()
+
+				repoPath := createRepoWithUpstream(t)
+				defaultBranch := getOriginDefaultBranchName(t, repoPath)
+				branch := "dsx-test-bs-merged"
+				runGit(t, repoPath, "checkout", "-b", branch)
+				writeTempFile(t, repoPath, "feature.txt", "content\n")
+				runGit(t, repoPath, "add", "feature.txt")
+				runGit(t, repoPath, "commit", "-m", "feature commit")
+				runGit(t, repoPath, "checkout", defaultBranch)
+				runGit(t, repoPath, "merge", "--no-ff", branch)
+
+				return repoPath, branch
+			},
+			wantInMerged: true,
+			wantBranch:   "dsx-test-bs-merged",
+		},
+		{
+			name: "未マージブランチは MERGED カテゴリに含まれない",
+			setupRepo: func(t *testing.T) (string, string) {
+				t.Helper()
+
+				repoPath := createRepoWithUpstream(t)
+				branch := "dsx-test-bs-unmerged"
+				runGit(t, repoPath, "checkout", "-b", branch)
+				writeTempFile(t, repoPath, "wip.txt", "wip\n")
+				runGit(t, repoPath, "add", "wip.txt")
+				runGit(t, repoPath, "commit", "-m", "wip commit")
+				defaultBranch := getOriginDefaultBranchName(t, repoPath)
+				runGit(t, repoPath, "checkout", defaultBranch)
+
+				return repoPath, branch
+			},
+			wantInMerged: false,
+			wantBranch:   "dsx-test-bs-unmerged",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			repoPath, branch := tt.setupRepo(t)
+
+			result, err := ScanBranches(context.Background(), repoPath, BranchScanOptions{Fetch: false})
+			if err != nil {
+				t.Fatalf("ScanBranches() error = %v", err)
+			}
+
+			inMerged := false
+
+			for _, c := range result.Candidates {
+				if c.Category == BranchCategoryMerged && c.Name == branch {
+					inMerged = true
+
+					break
+				}
+			}
+
+			if inMerged != tt.wantInMerged {
+				t.Errorf("MERGED に %q が含まれる = %v, want %v (candidates: %+v)", branch, inMerged, tt.wantInMerged, result.Candidates)
+			}
+		})
+	}
+}
+
+// TestScanBranches_Unmerged は未マージブランチが UNMERGED カテゴリに含まれることを確認します。
+func TestScanBranches_Unmerged(t *testing.T) {
+	t.Parallel()
+
+	repoPath := createRepoWithUpstream(t)
+	branch := "dsx-test-bs-wip"
+	defaultBranch := getOriginDefaultBranchName(t, repoPath)
+	runGit(t, repoPath, "checkout", "-b", branch)
+	writeTempFile(t, repoPath, "wip.txt", "wip\n")
+	runGit(t, repoPath, "add", "wip.txt")
+	runGit(t, repoPath, "commit", "-m", "wip commit")
+	runGit(t, repoPath, "checkout", defaultBranch)
+
+	result, err := ScanBranches(context.Background(), repoPath, BranchScanOptions{Fetch: false})
+	if err != nil {
+		t.Fatalf("ScanBranches() error = %v", err)
+	}
+
+	found := false
+
+	for _, c := range result.Candidates {
+		if c.Category == BranchCategoryUnmerged && c.Name == branch {
+			found = true
+
+			if c.Age == "" {
+				t.Errorf("UNMERGED 候補の Age が空です")
+			}
+
+			break
+		}
+	}
+
+	if !found {
+		t.Errorf("UNMERGED に %q が含まれていません (candidates: %+v)", branch, result.Candidates)
+	}
+}
+
+// TestScanBranches_MergeTransition は UNMERGED ブランチがマージ後に MERGED に移動することを確認します。
+func TestScanBranches_MergeTransition(t *testing.T) {
+	t.Parallel()
+
+	repoPath := createRepoWithUpstream(t)
+	branch := "dsx-test-bs-merge-transition"
+	defaultBranch := getOriginDefaultBranchName(t, repoPath)
+	runGit(t, repoPath, "checkout", "-b", branch)
+	runGit(t, repoPath, "commit", "--allow-empty", "-m", "empty commit")
+	runGit(t, repoPath, "checkout", defaultBranch)
+
+	// マージ前: UNMERGED にあるはず
+	result, err := ScanBranches(context.Background(), repoPath, BranchScanOptions{Fetch: false})
+	if err != nil {
+		t.Fatalf("ScanBranches() error = %v", err)
+	}
+
+	hasUnmerged := false
+
+	for _, c := range result.Candidates {
+		if c.Category == BranchCategoryUnmerged && c.Name == branch {
+			hasUnmerged = true
+
+			break
+		}
+	}
+
+	if !hasUnmerged {
+		t.Errorf("マージ前: UNMERGED に %q が含まれていません", branch)
+	}
+
+	// マージ後: MERGED にあるはず
+	runGit(t, repoPath, "merge", "--no-ff", branch)
+
+	result2, err := ScanBranches(context.Background(), repoPath, BranchScanOptions{Fetch: false})
+	if err != nil {
+		t.Fatalf("ScanBranches() error = %v (after merge)", err)
+	}
+
+	hasMerged := false
+
+	for _, c := range result2.Candidates {
+		if c.Category == BranchCategoryMerged && c.Name == branch {
+			hasMerged = true
+
+			break
+		}
+	}
+
+	if !hasMerged {
+		t.Errorf("マージ後: MERGED に %q が含まれていません", branch)
+	}
+}
+
+func TestScanBranches_NoUpstream(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		setupRepo    func(t *testing.T) (repoPath, branch string)
+		wantCategory BranchCategory
+		wantFound    bool
+	}{
+		{
+			name: "アップストリーム未設定の未マージブランチが NO_UPSTREAM に含まれる",
+			setupRepo: func(t *testing.T) (string, string) {
+				t.Helper()
+
+				repoPath := createRepoWithUpstream(t)
+				defaultBranch := getOriginDefaultBranchName(t, repoPath)
+				branch := "dsx-test-bs-noup"
+				runGit(t, repoPath, "checkout", "-b", branch)
+				runGit(t, repoPath, "commit", "--allow-empty", "-m", "local only")
+				// アップストリームを設定しない
+				runGit(t, repoPath, "checkout", defaultBranch)
+
+				return repoPath, branch
+			},
+			wantCategory: BranchCategoryNoUpstream,
+			wantFound:    true,
+		},
+		{
+			name: "アップストリーム設定済みのブランチは NO_UPSTREAM に含まれない",
+			setupRepo: func(t *testing.T) (string, string) {
+				t.Helper()
+
+				repoPath := createRepoWithUpstream(t)
+				defaultBranch := getOriginDefaultBranchName(t, repoPath)
+				branch := "dsx-test-bs-has-upstream"
+				runGit(t, repoPath, "checkout", "-b", branch)
+				runGit(t, repoPath, "commit", "--allow-empty", "-m", "with upstream")
+				runGit(t, repoPath, "push", "-u", "origin", "HEAD")
+				runGit(t, repoPath, "checkout", defaultBranch)
+
+				return repoPath, branch
+			},
+			wantCategory: BranchCategoryNoUpstream,
+			wantFound:    false,
+		},
+		{
+			name: "アップストリーム未設定でもマージ済みなら MERGED に含まれ NO_UPSTREAM には含まれない",
+			setupRepo: func(t *testing.T) (string, string) {
+				t.Helper()
+
+				repoPath := createRepoWithUpstream(t)
+				defaultBranch := getOriginDefaultBranchName(t, repoPath)
+				branch := "dsx-test-bs-merged-noup"
+				runGit(t, repoPath, "checkout", "-b", branch)
+				runGit(t, repoPath, "commit", "--allow-empty", "-m", "merged without upstream")
+				runGit(t, repoPath, "checkout", defaultBranch)
+				runGit(t, repoPath, "merge", "--no-ff", branch)
+
+				return repoPath, branch
+			},
+			wantCategory: BranchCategoryNoUpstream,
+			wantFound:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			repoPath, branch := tt.setupRepo(t)
+
+			result, err := ScanBranches(context.Background(), repoPath, BranchScanOptions{Fetch: false})
+			if err != nil {
+				t.Fatalf("ScanBranches() error = %v", err)
+			}
+
+			found := false
+
+			for _, c := range result.Candidates {
+				if c.Category == tt.wantCategory && c.Name == branch {
+					found = true
+
+					break
+				}
+			}
+
+			if found != tt.wantFound {
+				t.Errorf("カテゴリ %s に %q が含まれる = %v, want %v (candidates: %+v)",
+					tt.wantCategory, branch, found, tt.wantFound, result.Candidates)
+			}
+		})
+	}
+}
+
+func TestScanBranches_StaleRef(t *testing.T) {
+	t.Parallel()
+
+	t.Run("削除されたリモートブランチが STALE_REF に含まれる", func(t *testing.T) {
+		t.Parallel()
+
+		base := t.TempDir()
+		remotePath := filepath.Join(base, "remote.git")
+		workPath := filepath.Join(base, "work")
+
+		runGit(t, "", "init", "--bare", remotePath)
+		runGit(t, "", "clone", remotePath, workPath)
+		runGit(t, workPath, "config", "user.email", "dsx-test@example.com")
+		runGit(t, workPath, "config", "user.name", "dsx-test")
+
+		// 初期コミット
+		writeTempFile(t, workPath, "README.md", "# repo\n")
+		runGit(t, workPath, "add", "README.md")
+		runGit(t, workPath, "commit", "-m", "initial commit")
+		runGit(t, workPath, "push", "-u", "origin", "HEAD")
+		// origin/HEAD を設定（DetectDefaultBranch が必要とする）
+		runGit(t, workPath, "remote", "set-head", "origin", "--auto")
+
+		// ブランチをプッシュしてリモートに作成
+		branch := "dsx-test-bs-stale"
+		runGit(t, workPath, "checkout", "-b", branch)
+		runGit(t, workPath, "commit", "--allow-empty", "-m", "stale branch commit")
+		runGit(t, workPath, "push", "origin", branch)
+
+		defaultBranch := getOriginDefaultBranchName(t, workPath)
+		runGit(t, workPath, "checkout", defaultBranch)
+
+		// リモート（ベア）でブランチを削除 → work 側はまだ origin/dsx-test-bs-stale を持つ
+		// bare リポジトリでは -C が使えないため --git-dir を使う
+		runGit(t, "", "--git-dir="+remotePath, "update-ref", "-d", "refs/heads/"+branch)
+
+		result, err := ScanBranches(context.Background(), workPath, BranchScanOptions{Fetch: false})
+		if err != nil {
+			t.Fatalf("ScanBranches() error = %v", err)
+		}
+
+		found := false
+		expectedRef := "origin/" + branch
+
+		for _, c := range result.Candidates {
+			if c.Category == BranchCategoryStaleRef && c.Name == expectedRef {
+				found = true
+
+				break
+			}
+		}
+
+		if !found {
+			t.Errorf("STALE_REF に %q が含まれていません (candidates: %+v)", expectedRef, result.Candidates)
+		}
+	})
+}
+
+func TestScanBranches_Exclusion(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		exclude     []string
+		checkoutOn  string // 空の場合は default ブランチのまま
+		setupBranch string
+		wantPresent bool
+	}{
+		{
+			name:        "現在のブランチは候補に含まれない",
+			checkoutOn:  "dsx-test-bs-current",
+			setupBranch: "dsx-test-bs-current",
+			wantPresent: false,
+		},
+		{
+			name:        "--exclude に指定したブランチは候補に含まれない",
+			exclude:     []string{"dsx-test-bs-excluded"},
+			setupBranch: "dsx-test-bs-excluded",
+			wantPresent: false,
+		},
+		{
+			name:        "--exclude 未指定の場合はブランチが候補に含まれる",
+			setupBranch: "dsx-test-bs-included",
+			wantPresent: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			repoPath := createRepoWithUpstream(t)
+			defaultBranch := getOriginDefaultBranchName(t, repoPath)
+
+			runGit(t, repoPath, "checkout", "-b", tt.setupBranch)
+			runGit(t, repoPath, "commit", "--allow-empty", "-m", "test commit")
+
+			if tt.checkoutOn == "" {
+				runGit(t, repoPath, "checkout", defaultBranch)
+			}
+			// checkoutOn != "" の場合はそのブランチに留まる
+
+			result, err := ScanBranches(context.Background(), repoPath, BranchScanOptions{
+				Fetch:           false,
+				ExcludeBranches: tt.exclude,
+			})
+			if err != nil {
+				t.Fatalf("ScanBranches() error = %v", err)
+			}
+
+			found := false
+
+			for _, c := range result.Candidates {
+				if c.Name == tt.setupBranch {
+					found = true
+
+					break
+				}
+			}
+
+			if found != tt.wantPresent {
+				t.Errorf("候補に %q が含まれる = %v, want %v (candidates: %+v)",
+					tt.setupBranch, found, tt.wantPresent, result.Candidates)
+			}
+		})
+	}
+}
+
+func TestScanBranches_NoRemote(t *testing.T) {
+	t.Parallel()
+
+	t.Run("リモートなしリポジトリはエラーを返す", func(t *testing.T) {
+		t.Parallel()
+
+		repoPath := t.TempDir()
+		runGit(t, repoPath, "init")
+		runGit(t, repoPath, "config", "user.email", "dsx-test@example.com")
+		runGit(t, repoPath, "config", "user.name", "dsx-test")
+		writeTempFile(t, repoPath, "README.md", "# repo\n")
+		runGit(t, repoPath, "add", "README.md")
+		runGit(t, repoPath, "commit", "-m", "initial commit")
+
+		_, err := ScanBranches(context.Background(), repoPath, BranchScanOptions{Fetch: false})
+		if err == nil {
+			t.Fatalf("ScanBranches() error = nil, want error（リモートなし）")
+		}
+	})
+}
+
+func TestScanBranches_DefaultBranchExcluded(t *testing.T) {
+	t.Parallel()
+
+	t.Run("デフォルトブランチは候補に含まれない", func(t *testing.T) {
+		t.Parallel()
+
+		repoPath := createRepoWithUpstream(t)
+		defaultBranch := getOriginDefaultBranchName(t, repoPath)
+
+		result, err := ScanBranches(context.Background(), repoPath, BranchScanOptions{Fetch: false})
+		if err != nil {
+			t.Fatalf("ScanBranches() error = %v", err)
+		}
+
+		for _, c := range result.Candidates {
+			if c.Name == defaultBranch {
+				t.Errorf("デフォルトブランチ %q が候補に含まれています (category: %s)", defaultBranch, c.Category)
+			}
+		}
+	})
+}
+
+func TestCategoryLabel(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		category BranchCategory
+		want     string
+	}{
+		{BranchCategoryMerged, "[MERGED]"},
+		{BranchCategoryUnmerged, "[UNMERGED]"},
+		{BranchCategoryStaleRef, "[STALE-REF]"},
+		{BranchCategoryNoUpstream, "[NO-UPSTREAM]"},
+		{"unknown_category", "[UNKNOWN]"},
+	}
+
+	for _, tt := range tests {
+		got := CategoryLabel(tt.category)
+		if got != tt.want {
+			t.Errorf("CategoryLabel(%q) = %q, want %q", tt.category, got, tt.want)
+		}
+	}
+}
+
+func TestIsSafeToAutoDelete(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		category BranchCategory
+		want     bool
+	}{
+		{BranchCategoryMerged, true},
+		{BranchCategoryStaleRef, true},
+		{BranchCategoryUnmerged, false},
+		{BranchCategoryNoUpstream, false},
+		{"unknown_category", false},
+	}
+
+	for _, tt := range tests {
+		got := IsSafeToAutoDelete(tt.category)
+		if got != tt.want {
+			t.Errorf("IsSafeToAutoDelete(%q) = %v, want %v", tt.category, got, tt.want)
+		}
+	}
+}
+
+// writeTempFile はテスト用にリポジトリ内にファイルを書き込みます。
+func writeTempFile(t *testing.T, repoPath, filename, content string) {
+	t.Helper()
+
+	filePath := filepath.Join(repoPath, filename)
+	if err := os.WriteFile(filePath, []byte(content), 0o644); err != nil {
+		t.Fatalf("failed to write file %s: %v", filename, err)
+	}
+}
+
+func TestDeleteBranchCandidates_DryRun(t *testing.T) {
+	t.Parallel()
+
+	t.Run("dryRun=true では実際の削除は行われない", func(t *testing.T) {
+		t.Parallel()
+
+		repoPath, featureBranch := setupRepoWithMergedBranch(t)
+
+		candidates := []BranchCandidate{
+			{Name: featureBranch, Category: BranchCategoryMerged},
+		}
+
+		result, err := DeleteBranchCandidates(context.Background(), repoPath, candidates, true)
+		if err != nil {
+			t.Fatalf("DeleteBranchCandidates() error = %v", err)
+		}
+
+		if len(result.Deleted) != 1 || result.Deleted[0].Name != featureBranch {
+			t.Errorf("Deleted = %+v, want [{%s MERGED}]", result.Deleted, featureBranch)
+		}
+
+		// dryRun なので実際のブランチは残っているはず
+		exists, err := localBranchExists(context.Background(), repoPath, featureBranch)
+		if err != nil {
+			t.Fatalf("localBranchExists() error = %v", err)
+		}
+
+		if !exists {
+			t.Errorf("dryRun=true なのにブランチ %q が削除されました", featureBranch)
+		}
+	})
+}
+
+func TestDeleteBranchCandidates_Delete(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		setupRepo func(t *testing.T) (repoPath, branch string)
+		category  BranchCategory
+	}{
+		{
+			name:      "MERGED ブランチを安全削除（-d）",
+			setupRepo: setupRepoWithMergedBranch,
+			category:  BranchCategoryMerged,
+		},
+		{
+			name: "UNMERGED ブランチを強制削除（-D）",
+			setupRepo: func(t *testing.T) (string, string) {
+				t.Helper()
+
+				repoPath := createRepoWithUpstream(t)
+				defaultBranch := getOriginDefaultBranchName(t, repoPath)
+				branch := "dsx-test-bc-unmerged"
+				runGit(t, repoPath, "checkout", "-b", branch)
+				runGit(t, repoPath, "commit", "--allow-empty", "-m", "unmerged commit")
+				runGit(t, repoPath, "checkout", defaultBranch)
+
+				return repoPath, branch
+			},
+			category: BranchCategoryUnmerged,
+		},
+		{
+			name: "NO_UPSTREAM ブランチを強制削除（-D）",
+			setupRepo: func(t *testing.T) (string, string) {
+				t.Helper()
+
+				repoPath := createRepoWithUpstream(t)
+				defaultBranch := getOriginDefaultBranchName(t, repoPath)
+				branch := "dsx-test-bc-noup"
+				runGit(t, repoPath, "checkout", "-b", branch)
+				runGit(t, repoPath, "commit", "--allow-empty", "-m", "local only")
+				runGit(t, repoPath, "checkout", defaultBranch)
+
+				return repoPath, branch
+			},
+			category: BranchCategoryNoUpstream,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			repoPath, branch := tt.setupRepo(t)
+			candidates := []BranchCandidate{{Name: branch, Category: tt.category}}
+
+			result, err := DeleteBranchCandidates(context.Background(), repoPath, candidates, false)
+			if err != nil {
+				t.Fatalf("DeleteBranchCandidates() error = %v", err)
+			}
+
+			if len(result.Deleted) != 1 {
+				t.Errorf("Deleted = %+v, want 1 item", result.Deleted)
+			}
+
+			exists, err := localBranchExists(context.Background(), repoPath, branch)
+			if err != nil {
+				t.Fatalf("localBranchExists() error = %v", err)
+			}
+
+			if exists {
+				t.Errorf("ブランチ %q が削除されていません", branch)
+			}
+		})
+	}
+}
+
+// setupRepoWithMergedBranch はマージ済みフィーチャーブランチを持つリポジトリを作成します。
+func setupRepoWithMergedBranch(t *testing.T) (repoPath, branch string) {
+	t.Helper()
+
+	repoPath = createRepoWithUpstream(t)
+	defaultBranch := getOriginDefaultBranchName(t, repoPath)
+	branch = "dsx-test-bc-merged"
+	runGit(t, repoPath, "checkout", "-b", branch)
+	runGit(t, repoPath, "commit", "--allow-empty", "-m", "merged commit")
+	runGit(t, repoPath, "checkout", defaultBranch)
+	runGit(t, repoPath, "merge", "--no-ff", branch)
+
+	return repoPath, branch
+}
+
+func TestScanBranches_EmptyRepo(t *testing.T) {
+	t.Parallel()
+
+	t.Run("候補なしリポジトリは空スライスを返す", func(t *testing.T) {
+		t.Parallel()
+
+		// ブランチを追加せずにリポジトリだけ作成
+		repoPath := createRepoWithUpstream(t)
+
+		result, err := ScanBranches(context.Background(), repoPath, BranchScanOptions{Fetch: false})
+		if err != nil {
+			t.Fatalf("ScanBranches() error = %v", err)
+		}
+
+		// デフォルトブランチしかないので候補は0件
+		// (デフォルトブランチは excluded なのでゼロ件のはず)
+		// ただしアップストリーム未設定の他のブランチが出ないかチェック
+		for _, c := range result.Candidates {
+			t.Errorf("候補なしリポジトリに候補が含まれています: %+v", c)
+		}
+	})
+}
+
+func TestScanBranches_ResultFields(t *testing.T) {
+	t.Parallel()
+
+	t.Run("BranchScanResult のフィールドが正しく設定される", func(t *testing.T) {
+		t.Parallel()
+
+		repoPath := createRepoWithUpstream(t)
+
+		result, err := ScanBranches(context.Background(), repoPath, BranchScanOptions{Fetch: false})
+		if err != nil {
+			t.Fatalf("ScanBranches() error = %v", err)
+		}
+
+		if strings.TrimSpace(result.DefaultBranch) == "" {
+			t.Errorf("DefaultBranch が空です")
+		}
+
+		if strings.TrimSpace(result.CurrentBranch) == "" {
+			t.Errorf("CurrentBranch が空です")
+		}
+
+		if strings.TrimSpace(result.RepoPath) == "" {
+			t.Errorf("RepoPath が空です")
+		}
+	})
+}

--- a/internal/repo/branch_scan_test.go
+++ b/internal/repo/branch_scan_test.go
@@ -188,7 +188,7 @@ func TestScanBranches_NoUpstream(t *testing.T) {
 		wantFound    bool
 	}{
 		{
-			name: "アップストリーム未設定の未マージブランチが NO_UPSTREAM に含まれる",
+			name: "アップストリーム未設定の未マージブランチは UNMERGED に分類され NO_UPSTREAM には含まれない",
 			setupRepo: func(t *testing.T) (string, string) {
 				t.Helper()
 
@@ -203,7 +203,7 @@ func TestScanBranches_NoUpstream(t *testing.T) {
 				return repoPath, branch
 			},
 			wantCategory: BranchCategoryNoUpstream,
-			wantFound:    true,
+			wantFound:    false,
 		},
 		{
 			name: "アップストリーム設定済みのブランチは NO_UPSTREAM に含まれない",
@@ -270,6 +270,40 @@ func TestScanBranches_NoUpstream(t *testing.T) {
 					tt.wantCategory, branch, found, tt.wantFound, result.Candidates)
 			}
 		})
+	}
+}
+
+// TestScanBranches_NoCategoryDuplication は、同じブランチが複数のカテゴリに
+// 重複して分類されないことを検証します。重複があると DeleteBranchCandidates が
+// 同じブランチを2回削除しようとして失敗するため、回帰テストとして固定します。
+func TestScanBranches_NoCategoryDuplication(t *testing.T) {
+	t.Parallel()
+
+	repoPath := createRepoWithUpstream(t)
+	defaultBranch := getOriginDefaultBranchName(t, repoPath)
+
+	// アップストリーム未設定かつ未マージのブランチを作成
+	branch := "dsx-test-bs-dup"
+	runGit(t, repoPath, "checkout", "-b", branch)
+	runGit(t, repoPath, "commit", "--allow-empty", "-m", "no upstream and unmerged")
+	runGit(t, repoPath, "checkout", defaultBranch)
+
+	result, err := ScanBranches(context.Background(), repoPath, BranchScanOptions{Fetch: false})
+	if err != nil {
+		t.Fatalf("ScanBranches() error = %v", err)
+	}
+
+	count := 0
+
+	for _, c := range result.Candidates {
+		if c.Name == branch {
+			count++
+		}
+	}
+
+	if count != 1 {
+		t.Errorf("ブランチ %q が %d 回出現しました (期待値: 1, candidates: %+v)",
+			branch, count, result.Candidates)
 	}
 }
 

--- a/internal/repo/branch_scan_test.go
+++ b/internal/repo/branch_scan_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -830,4 +831,118 @@ func TestScanBranches_ResultFields(t *testing.T) {
 			t.Errorf("RepoPath が空です")
 		}
 	})
+}
+
+// TestDeleteBranchCandidates_StaleRefIndividual は STALE_REF を候補単位で削除し、
+// 選択されなかった STALE_REF が残ることを検証します（PR #66 レビュー指摘対応）。
+// 以前は git remote prune <remote> でリモート単位の一括削除を行っていたため、
+// ユーザーが一部の STALE_REF だけを選択しても全件が prune される不整合がありました。
+func TestDeleteBranchCandidates_StaleRefIndividual(t *testing.T) {
+	t.Parallel()
+
+	base := t.TempDir()
+	remotePath := filepath.Join(base, "remote.git")
+	workPath := filepath.Join(base, "work")
+
+	runGit(t, "", "init", "--bare", remotePath)
+	runGit(t, "", "clone", remotePath, workPath)
+	runGit(t, workPath, "config", "user.email", "dsx-test@example.com")
+	runGit(t, workPath, "config", "user.name", "dsx-test")
+
+	writeTempFile(t, workPath, "README.md", "# repo\n")
+	runGit(t, workPath, "add", "README.md")
+	runGit(t, workPath, "commit", "-m", "initial commit")
+	runGit(t, workPath, "push", "-u", "origin", "HEAD")
+	runGit(t, workPath, "remote", "set-head", "origin", "--auto")
+
+	defaultBranch := getOriginDefaultBranchName(t, workPath)
+
+	staleA := "dsx-test-stale-a"
+	staleB := "dsx-test-stale-b"
+
+	for _, b := range []string{staleA, staleB} {
+		runGit(t, workPath, "checkout", "-b", b)
+		runGit(t, workPath, "commit", "--allow-empty", "-m", b+" commit")
+		runGit(t, workPath, "push", "origin", b)
+		runGit(t, workPath, "checkout", defaultBranch)
+	}
+
+	runGit(t, "", "--git-dir="+remotePath, "update-ref", "-d", "refs/heads/"+staleA)
+	runGit(t, "", "--git-dir="+remotePath, "update-ref", "-d", "refs/heads/"+staleB)
+
+	candidates := []BranchCandidate{
+		{Name: "origin/" + staleA, Category: BranchCategoryStaleRef, Remote: "origin"},
+	}
+
+	result, err := DeleteBranchCandidates(context.Background(), workPath, candidates, false, false, defaultBranch)
+	if err != nil {
+		t.Fatalf("DeleteBranchCandidates() error = %v", err)
+	}
+
+	if len(result.Pruned) != 1 || result.Pruned[0].Name != "origin/"+staleA {
+		t.Errorf("Pruned = %+v, want 1 item (origin/%s)", result.Pruned, staleA)
+	}
+
+	if remoteTrackingRefExists(t, workPath, "origin/"+staleA) {
+		t.Errorf("origin/%s が削除されていません", staleA)
+	}
+
+	if !remoteTrackingRefExists(t, workPath, "origin/"+staleB) {
+		t.Errorf("origin/%s が誤って削除されました（候補単位削除の挙動違反）", staleB)
+	}
+}
+
+// TestDeleteBranchCandidates_StaleRefDryRun は dryRun=true のときに
+// 実際の ref が削除されないことを検証します。
+func TestDeleteBranchCandidates_StaleRefDryRun(t *testing.T) {
+	t.Parallel()
+
+	base := t.TempDir()
+	remotePath := filepath.Join(base, "remote.git")
+	workPath := filepath.Join(base, "work")
+
+	runGit(t, "", "init", "--bare", remotePath)
+	runGit(t, "", "clone", remotePath, workPath)
+	runGit(t, workPath, "config", "user.email", "dsx-test@example.com")
+	runGit(t, workPath, "config", "user.name", "dsx-test")
+
+	writeTempFile(t, workPath, "README.md", "# repo\n")
+	runGit(t, workPath, "add", "README.md")
+	runGit(t, workPath, "commit", "-m", "initial commit")
+	runGit(t, workPath, "push", "-u", "origin", "HEAD")
+	runGit(t, workPath, "remote", "set-head", "origin", "--auto")
+
+	defaultBranch := getOriginDefaultBranchName(t, workPath)
+	stale := "dsx-test-stale-dryrun"
+	runGit(t, workPath, "checkout", "-b", stale)
+	runGit(t, workPath, "commit", "--allow-empty", "-m", "dryrun stale commit")
+	runGit(t, workPath, "push", "origin", stale)
+	runGit(t, workPath, "checkout", defaultBranch)
+	runGit(t, "", "--git-dir="+remotePath, "update-ref", "-d", "refs/heads/"+stale)
+
+	candidates := []BranchCandidate{
+		{Name: "origin/" + stale, Category: BranchCategoryStaleRef, Remote: "origin"},
+	}
+
+	result, err := DeleteBranchCandidates(context.Background(), workPath, candidates, true, false, defaultBranch)
+	if err != nil {
+		t.Fatalf("DeleteBranchCandidates() error = %v", err)
+	}
+
+	if len(result.Pruned) != 1 {
+		t.Errorf("dryRun Pruned = %+v, want 1 item", result.Pruned)
+	}
+
+	if !remoteTrackingRefExists(t, workPath, "origin/"+stale) {
+		t.Errorf("dryRun なのに origin/%s が削除されています", stale)
+	}
+}
+
+// remoteTrackingRefExists はリモートトラッキング参照 refs/remotes/<ref> の存在を返します。
+func remoteTrackingRefExists(t *testing.T, repoPath, ref string) bool {
+	t.Helper()
+
+	cmd := exec.CommandContext(context.Background(), "git", "-C", repoPath, "show-ref", "--verify", "--quiet", "refs/remotes/"+ref)
+
+	return cmd.Run() == nil
 }

--- a/internal/repo/branch_scan_test.go
+++ b/internal/repo/branch_scan_test.go
@@ -98,6 +98,10 @@ func TestScanBranches_Unmerged(t *testing.T) {
 	writeTempFile(t, repoPath, "wip.txt", "wip\n")
 	runGit(t, repoPath, "add", "wip.txt")
 	runGit(t, repoPath, "commit", "-m", "wip commit")
+	// upstream を設定して push → リモート側を削除して gone 状態を作る（新仕様の UNMERGED 条件）
+	runGit(t, repoPath, "push", "-u", "origin", branch)
+	runGit(t, repoPath, "push", "origin", "--delete", branch)
+	runGit(t, repoPath, "fetch", "--prune")
 	runGit(t, repoPath, "checkout", defaultBranch)
 
 	result, err := ScanBranches(context.Background(), repoPath, BranchScanOptions{Fetch: false})
@@ -124,7 +128,7 @@ func TestScanBranches_Unmerged(t *testing.T) {
 	}
 }
 
-// TestScanBranches_MergeTransition は UNMERGED ブランチがマージ後に MERGED に移動することを確認します。
+// TestScanBranches_MergeTransition は UNMERGED（upstream gone）ブランチがマージ後に MERGED に移動することを確認します。
 func TestScanBranches_MergeTransition(t *testing.T) {
 	t.Parallel()
 
@@ -133,6 +137,10 @@ func TestScanBranches_MergeTransition(t *testing.T) {
 	defaultBranch := getOriginDefaultBranchName(t, repoPath)
 	runGit(t, repoPath, "checkout", "-b", branch)
 	runGit(t, repoPath, "commit", "--allow-empty", "-m", "empty commit")
+	// upstream を gone 状態にしてマージ前は UNMERGED に分類されることを確認
+	runGit(t, repoPath, "push", "-u", "origin", branch)
+	runGit(t, repoPath, "push", "origin", "--delete", branch)
+	runGit(t, repoPath, "fetch", "--prune")
 	runGit(t, repoPath, "checkout", defaultBranch)
 
 	// マージ前: UNMERGED にあるはず
@@ -188,7 +196,7 @@ func TestScanBranches_NoUpstream(t *testing.T) {
 		wantFound    bool
 	}{
 		{
-			name: "アップストリーム未設定の未マージブランチは UNMERGED に分類され NO_UPSTREAM には含まれない",
+			name: "アップストリーム未設定の未マージブランチは NO_UPSTREAM に分類される",
 			setupRepo: func(t *testing.T) (string, string) {
 				t.Helper()
 
@@ -203,7 +211,7 @@ func TestScanBranches_NoUpstream(t *testing.T) {
 				return repoPath, branch
 			},
 			wantCategory: BranchCategoryNoUpstream,
-			wantFound:    false,
+			wantFound:    true,
 		},
 		{
 			name: "アップストリーム設定済みのブランチは NO_UPSTREAM に含まれない",
@@ -545,7 +553,7 @@ func TestDeleteBranchCandidates_DryRun(t *testing.T) {
 			{Name: featureBranch, Category: BranchCategoryMerged},
 		}
 
-		result, err := DeleteBranchCandidates(context.Background(), repoPath, candidates, true)
+		result, err := DeleteBranchCandidates(context.Background(), repoPath, candidates, true, false)
 		if err != nil {
 			t.Fatalf("DeleteBranchCandidates() error = %v", err)
 		}
@@ -621,7 +629,7 @@ func TestDeleteBranchCandidates_Delete(t *testing.T) {
 			repoPath, branch := tt.setupRepo(t)
 			candidates := []BranchCandidate{{Name: branch, Category: tt.category}}
 
-			result, err := DeleteBranchCandidates(context.Background(), repoPath, candidates, false)
+			result, err := DeleteBranchCandidates(context.Background(), repoPath, candidates, false, true)
 			if err != nil {
 				t.Fatalf("DeleteBranchCandidates() error = %v", err)
 			}

--- a/internal/repo/branch_scan_test.go
+++ b/internal/repo/branch_scan_test.go
@@ -2,11 +2,46 @@ package repo
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
+
+func TestFormatRelativeAgeJP(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name    string
+		unixStr string
+		want    string
+	}{
+		{"空文字列", "", ""},
+		{"パース失敗", "not-a-number", ""},
+		{"未来日付（負の差）はたった今", fmt.Sprintf("%d", now.Add(10*time.Hour).Unix()), "たった今"},
+		{"30秒前はたった今", fmt.Sprintf("%d", now.Add(-30*time.Second).Unix()), "たった今"},
+		{"5分前", fmt.Sprintf("%d", now.Add(-5*time.Minute).Unix()), "5分前"},
+		{"2時間前", fmt.Sprintf("%d", now.Add(-2*time.Hour).Unix()), "2時間前"},
+		{"3日前", fmt.Sprintf("%d", now.Add(-3*24*time.Hour).Unix()), "3日前"},
+		{"2週間前", fmt.Sprintf("%d", now.Add(-14*24*time.Hour).Unix()), "2週間前"},
+		{"3ヶ月前", fmt.Sprintf("%d", now.Add(-90*24*time.Hour).Unix()), "3ヶ月前"},
+		{"2年前", fmt.Sprintf("%d", now.Add(-2*365*24*time.Hour).Unix()), "2年前"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := formatRelativeAgeJP(tt.unixStr, now)
+			if got != tt.want {
+				t.Errorf("formatRelativeAgeJP(%q, now) = %q, want %q", tt.unixStr, got, tt.want)
+			}
+		})
+	}
+}
 
 func TestScanBranches_Merged(t *testing.T) {
 	t.Parallel()
@@ -553,7 +588,7 @@ func TestDeleteBranchCandidates_DryRun(t *testing.T) {
 			{Name: featureBranch, Category: BranchCategoryMerged},
 		}
 
-		result, err := DeleteBranchCandidates(context.Background(), repoPath, candidates, true, false)
+		result, err := DeleteBranchCandidates(context.Background(), repoPath, candidates, true, false, "")
 		if err != nil {
 			t.Fatalf("DeleteBranchCandidates() error = %v", err)
 		}
@@ -629,7 +664,7 @@ func TestDeleteBranchCandidates_Delete(t *testing.T) {
 			repoPath, branch := tt.setupRepo(t)
 			candidates := []BranchCandidate{{Name: branch, Category: tt.category}}
 
-			result, err := DeleteBranchCandidates(context.Background(), repoPath, candidates, false, true)
+			result, err := DeleteBranchCandidates(context.Background(), repoPath, candidates, false, true, "")
 			if err != nil {
 				t.Fatalf("DeleteBranchCandidates() error = %v", err)
 			}
@@ -663,6 +698,88 @@ func setupRepoWithMergedBranch(t *testing.T) (repoPath, branch string) {
 	runGit(t, repoPath, "merge", "--no-ff", branch)
 
 	return repoPath, branch
+}
+
+// setupRepoWithMergedBranchOnOtherCheckout はデフォルトブランチへマージ済みの
+// フィーチャーブランチを作成した上で、マージコミットを含まない別の作業ブランチを
+// checkout した状態にします（リリース後に別作業ブランチで作業中のケース）。
+// この状態では `git branch -d <feature>` は HEAD から到達できないため失敗します。
+func setupRepoWithMergedBranchOnOtherCheckout(t *testing.T) (repoPath, branch, defaultBranch string) {
+	t.Helper()
+
+	repoPath = createRepoWithUpstream(t)
+	defaultBranch = getOriginDefaultBranchName(t, repoPath)
+	preMergeSHA := strings.TrimSpace(string(runGitCommandOutputOrFail(t, repoPath, "rev-parse", "HEAD")))
+	branch = "dsx-test-bc-merged-other"
+	runGit(t, repoPath, "checkout", "-b", branch)
+	runGit(t, repoPath, "commit", "--allow-empty", "-m", "merged commit")
+	runGit(t, repoPath, "checkout", defaultBranch)
+	runGit(t, repoPath, "merge", "--no-ff", branch)
+	// マージコミットを含まない位置（マージ前 SHA）から別の作業ブランチを切る
+	runGit(t, repoPath, "checkout", "-b", "dsx-test-bc-other-work", preMergeSHA)
+
+	return repoPath, branch, defaultBranch
+}
+
+// TestDeleteBranchCandidates_MergedOnOtherCheckout は、ユーザーがデフォルトブランチ以外を
+// checkout している状態でも MERGED ブランチが正しく削除されることを検証します
+// （内部で merge-base --is-ancestor によりデフォルトブランチへのマージを再確認し -D で削除）。
+func TestDeleteBranchCandidates_MergedOnOtherCheckout(t *testing.T) {
+	t.Parallel()
+
+	t.Run("デフォルト以外を checkout 中でも MERGED は defaultBranch 指定で削除される", func(t *testing.T) {
+		t.Parallel()
+
+		repoPath, mergedBranch, defaultBranch := setupRepoWithMergedBranchOnOtherCheckout(t)
+		candidates := []BranchCandidate{{Name: mergedBranch, Category: BranchCategoryMerged}}
+
+		result, err := DeleteBranchCandidates(context.Background(), repoPath, candidates, false, false, defaultBranch)
+		if err != nil {
+			t.Fatalf("DeleteBranchCandidates() error = %v, result = %+v", err, result)
+		}
+
+		if len(result.Deleted) != 1 || result.Deleted[0].Name != mergedBranch {
+			t.Errorf("Deleted = %+v, want 1 item (%s)", result.Deleted, mergedBranch)
+		}
+
+		exists, existsErr := localBranchExists(context.Background(), repoPath, mergedBranch)
+		if existsErr != nil {
+			t.Fatalf("localBranchExists() error = %v", existsErr)
+		}
+
+		if exists {
+			t.Errorf("MERGED ブランチ %q が削除されていません（defaultBranch 救済が機能していない）", mergedBranch)
+		}
+	})
+
+	t.Run("defaultBranch が空のときは救済されず Errors に入る", func(t *testing.T) {
+		t.Parallel()
+
+		repoPath, mergedBranch, _ := setupRepoWithMergedBranchOnOtherCheckout(t)
+		candidates := []BranchCandidate{{Name: mergedBranch, Category: BranchCategoryMerged}}
+
+		result, err := DeleteBranchCandidates(context.Background(), repoPath, candidates, false, false, "")
+		if err != nil {
+			t.Logf("DeleteBranchCandidates() error = %v（このケースでは Errors に入る想定なので nil でも可）", err)
+		}
+
+		if result == nil {
+			t.Fatalf("result が nil")
+		}
+
+		if len(result.Errors) == 0 {
+			t.Errorf("defaultBranch='' のときは -d 失敗で Errors に入るべき: result = %+v", result)
+		}
+
+		exists, existsErr := localBranchExists(context.Background(), repoPath, mergedBranch)
+		if existsErr != nil {
+			t.Fatalf("localBranchExists() error = %v", existsErr)
+		}
+
+		if !exists {
+			t.Errorf("defaultBranch='' で救済されないはずなのにブランチが削除されました")
+		}
+	})
 }
 
 func TestScanBranches_EmptyRepo(t *testing.T) {

--- a/internal/repo/cleanup.go
+++ b/internal/repo/cleanup.go
@@ -13,6 +13,9 @@ import (
 const (
 	cleanupTargetMerged   = "merged"
 	cleanupTargetSquashed = "squashed"
+
+	// defaultRemoteName は標準的なリモート名 "origin" を表す共通定数です。
+	defaultRemoteName = "origin"
 )
 
 // DefaultBranchInfo はリポジトリのデフォルトブランチ情報です。
@@ -66,8 +69,8 @@ func detectCleanupRemote(ctx context.Context, repoPath string) (string, error) {
 		}
 	}
 
-	if containsString(remotes, "origin") {
-		return "origin", nil
+	if containsString(remotes, defaultRemoteName) {
+		return defaultRemoteName, nil
 	}
 
 	if len(remotes) == 1 {

--- a/internal/repo/update.go
+++ b/internal/repo/update.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strconv"
@@ -479,6 +480,28 @@ func getBehindCount(ctx context.Context, repoPath string) (int, error) {
 func runGitCommandOutput(ctx context.Context, repoPath string, args ...string) ([]byte, error) {
 	commandArgs := append([]string{"-C", repoPath}, args...)
 	cmd := exec.CommandContext(ctx, "git", commandArgs...)
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		message := strings.TrimSpace(string(output))
+		if message == "" {
+			return nil, err
+		}
+
+		return nil, fmt.Errorf("%w: %s", err, message)
+	}
+
+	return output, nil
+}
+
+// runGitCommandOutputLocaleC は LANG/LC_ALL=C を強制して git コマンドを実行します。
+// 出力を文字列パースする処理（ロケール依存メッセージの解析等）で使用します。
+func runGitCommandOutputLocaleC(ctx context.Context, repoPath string, args ...string) ([]byte, error) {
+	commandArgs := append([]string{"-C", repoPath}, args...)
+
+	cmd := exec.CommandContext(ctx, "git", commandArgs...)
+
+	cmd.Env = append(os.Environ(), "LANG=C", "LC_ALL=C")
 
 	output, err := cmd.CombinedOutput()
 	if err != nil {

--- a/tasks.md
+++ b/tasks.md
@@ -6,7 +6,20 @@
 
 ---
 
-## Issue #29: 一括pullが成功表示にも関わらず同期されない問題
+## Issue #1: dsx repo branch-clean サブコマンド実装
+
+- [x] `internal/repo/branch_scan.go` 実装（4カテゴリ検出ロジック）
+- [x] `internal/repo/branch_clean.go` 実装（削除・prune ロジック）
+- [x] `cmd/dsx/repo_branch_clean.go` 実装（Cobra コマンド定義・インタラクティブ/dry-run/yes モード）
+- [x] `internal/repo/branch_scan_test.go` テスト追加（table-driven・境界値・エラー系）
+- [x] `task check` 通過（fmt/vet/test/lint 全件パス、lint 0 issues）
+- [x] `CHANGELOG.md` 更新
+- [ ] feature ブランチ作成・コミット・push
+- [ ] Draft PR 作成（Closes #1）
+
+---
+
+
 
 ### 修正1（高優先）: `refs/remotes/origin/HEAD` 未設定時のスキップを廃止
 

--- a/tasks.md
+++ b/tasks.md
@@ -21,6 +21,8 @@
 
 
 
+## Issue #29: dsx repo update のブランチ更新状態確認スクリプト連携
+
 ### 修正1（高優先）: `refs/remotes/origin/HEAD` 未設定時のスキップを廃止
 
 対象: `internal/repo/update.go`


### PR DESCRIPTION
## 概要

Issue #1 の実装。ローカルリポジトリの不要ブランチを検出・削除する \dsx repo branch-clean\ サブコマンドを追加。

## 変更内容

### 新規ファイル

- \internal/repo/branch_scan.go\ — 4カテゴリのブランチスキャンロジック
- \internal/repo/branch_clean.go\ — ブランチ削除・prune 実行ロジック
- \internal/repo/branch_scan_test.go\ — テーブル駆動テスト（全カテゴリ・除外・削除を網羅）
- \cmd/dsx/repo_branch_clean.go\ — Cobra コマンド定義

### 検出カテゴリ

| カテゴリ | 説明 |
|----------|------|
| \MERGED\ | デフォルトブランチまたは指定ブランチにマージ済み |
| \UNMERGED\ | 未マージだが上流ブランチが削除済み |
| \STALE-REF\ | リモートの参照が消えた（prune 対象） |
| \NO-UPSTREAM\ | 上流ブランチが設定されていない |

### 実行モード

| モード | 説明 |
|--------|------|
| デフォルト（インタラクティブ） | \survey/v2\ MultiSelect で削除するブランチを選択。MERGED・STALE-REF をデフォルト選択 |
| \--dry-run\ | 削除対象を表示するのみ（実際には削除しない） |
| \--yes\ | 対話なしで MERGED・STALE-REF を自動削除 |

### その他オプション

- \--exclude <branch>\ — 除外ブランチを指定（複数回使用可）
- \--no-fetch\ — スキャン前の \git fetch --prune\ をスキップ

## 品質確認

- \	ask check\（fmt/vet/test/lint）全通過、lint 0 issues
- テーブル駆動テスト：全カテゴリ・除外・StaleRef・NoUpstream・削除を網羅

Closes #1