### PR TITLE
fix: dsx env export のパスワード二重入力と PowerShell BW_SESSION 破損を修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@
 
 ## [Unreleased]
 
+## [v0.6.2] - 2026-05-19
+
+### Fixed
+
+- `dsx env export` が `EnsureBitwardenSession()` を二重呼び出しし、パスワード入力を2回要求してしまう問題を修正（`getEnvVarsFunc()` が内部で `EnsureBitwardenSession()` を呼び出すため、`runEnvExport` からの直接呼び出しを排除）
+- PowerShell `dsx-unlock` が `bw unlock --raw` のマルチライン出力（アップデート通知等）を正しく処理できず `$env:BW_SESSION` に無効な値が設定される問題を修正（最後の非空行のみをセッショントークンとして使用するよう変更）
+- `dsx config init` が生成する `init.ps1` の `dsx-unlock` に同上の修正を適用
+- インストール済み `~/.config/dsx/init.ps1` を即時修正（再実行不要）
+
 ## [v0.6.1] - 2026-05-19
 
 ### Fixed

--- a/cmd/dsx/config.go
+++ b/cmd/dsx/config.go
@@ -1192,8 +1192,12 @@ function dsx-unlock {
     return $false
   }
 
-  $token = & bw unlock --raw
-  if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($token)) {
+  # bw unlock --raw はアップデート通知等が stdout に混入する場合があるため、
+  # 最後の非空行のみをセッショントークンとして使用する
+  $rawOutput = @(& bw unlock --raw)
+  $bwExitCode = $LASTEXITCODE
+  $token = ($rawOutput | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Last 1)
+  if ($bwExitCode -ne 0 -or [string]::IsNullOrWhiteSpace($token)) {
     Write-Error "Bitwarden のアンロックに失敗しました。"
     return $false
   }

--- a/cmd/dsx/config_test.go
+++ b/cmd/dsx/config_test.go
@@ -525,7 +525,8 @@ func TestGeneratedShellScripts(t *testing.T) {
 			requiredPhrases: []string{
 				`Get-Command dsx`,
 				`bw login --check`,
-				`$token = & bw unlock --raw`,
+				`$rawOutput = @(& bw unlock --raw)`,
+				`$token = ($rawOutput | Where-Object`,
 				`$needsUnlock = -not $env:BW_SESSION`,
 				`$null = & $DSX_PATH env status --quiet 2>$null`,
 				`if ($LASTEXITCODE -ne 0) {`,

--- a/cmd/dsx/env.go
+++ b/cmd/dsx/env.go
@@ -86,7 +86,6 @@ var envUnlockSync bool
 var envStatusQuiet bool
 
 var (
-	ensureBitwardenSessionFunc    = secret.EnsureBitwardenSession
 	getEnvVarsFunc                = secret.GetEnvVars
 	getBitwardenSessionStatusFunc = secret.GetBitwardenSessionStatus
 	exportFormatFunc              = secret.ExportFormat
@@ -106,16 +105,15 @@ func init() {
 }
 
 func runEnvExport(cmd *cobra.Command, args []string) error {
-	sessionToken, err := ensureBitwardenSessionFunc()
-	if err != nil {
-		return fmt.Errorf("環境変数の取得に失敗しました: %w", err)
-	}
-
-	// Bitwardenから環境変数を取得
+	// GetEnvVars が内部で EnsureBitwardenSession を呼び出し、
+	// 必要に応じて対話的アンロックを行い BW_SESSION を更新する
 	envVars, err := getEnvVarsFunc()
 	if err != nil {
 		return fmt.Errorf("環境変数の取得に失敗しました: %w", err)
 	}
+
+	// EnsureBitwardenSession による BW_SESSION 更新後の最新値を取得
+	sessionToken := os.Getenv("BW_SESSION")
 
 	// シェル用の形式でフォーマット
 	output, err := exportFormatFunc(envVars)

--- a/cmd/dsx/env_test.go
+++ b/cmd/dsx/env_test.go
@@ -14,7 +14,6 @@ import (
 func setupEnvCommandMocks(t *testing.T) {
 	t.Helper()
 
-	origEnsure := ensureBitwardenSessionFunc
 	origGetEnvVars := getEnvVarsFunc
 	origGetStatus := getBitwardenSessionStatusFunc
 	origExportFormat := exportFormatFunc
@@ -23,7 +22,6 @@ func setupEnvCommandMocks(t *testing.T) {
 	origStatusQuiet := envStatusQuiet
 
 	t.Cleanup(func() {
-		ensureBitwardenSessionFunc = origEnsure
 		getEnvVarsFunc = origGetEnvVars
 		getBitwardenSessionStatusFunc = origGetStatus
 		exportFormatFunc = origExportFormat
@@ -36,7 +34,7 @@ func setupEnvCommandMocks(t *testing.T) {
 func TestRunEnvExport(t *testing.T) {
 	tests := []struct {
 		name           string
-		ensureErr      error
+		bwSession      string
 		getEnvErr      error
 		exportErr      error
 		sessionErr     error
@@ -46,12 +44,13 @@ func TestRunEnvExport(t *testing.T) {
 	}{
 		{
 			name:           "BW_SESSIONを先頭に含めて環境変数を出力する",
+			bwSession:      "session-token",
 			wantOutput:     []string{"SESSION_EXPORT", "ENV_EXPORT"},
 			wantSessionMap: map[string]string{"BW_SESSION": "session-token"},
 		},
 		{
 			name:      "セッション確保失敗は環境変数取得エラーとして返す",
-			ensureErr: errors.New("unlock failed"),
+			getEnvErr: errors.New("unlock failed"),
 			wantErr:   "環境変数の取得に失敗しました",
 		},
 		{
@@ -75,9 +74,10 @@ func TestRunEnvExport(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			setupEnvCommandMocks(t)
 
-			ensureBitwardenSessionFunc = func() (string, error) {
-				return "session-token", tt.ensureErr
+			if tt.bwSession != "" {
+				t.Setenv("BW_SESSION", tt.bwSession)
 			}
+
 			getEnvVarsFunc = func() (map[string]string, error) {
 				return map[string]string{"TEST_VAR": "secret-value"}, tt.getEnvErr
 			}


### PR DESCRIPTION
## Summary

- `runEnvExport` が `EnsureBitwardenSession()` を二重呼び出しし、パスワード入力を2回要求する問題を修正
- PowerShell `dsx-unlock` が `bw unlock --raw` のマルチライン出力（アップデート通知等の stdout 混入）を正しく処理できず `$env:BW_SESSION` に無効な値が設定される根本原因を修正
- インストール済み `~/.config/dsx/init.ps1` も即時修正済み（`dsx config init` 再実行不要）

## 根本原因

**問題1: Go 側の二重アンロック**  
`runEnvExport` は `ensureBitwardenSessionFunc()` を直接呼び出した後、`getEnvVarsFunc()` を呼び出していた。`GetEnvVars()` は内部で `EnsureBitwardenSession()` を再呼び出しするため、パスワードプロンプトが2回表示されていた。

**問題2: PowerShell 側の BW_SESSION 破損**  
`bw unlock --raw` が stdout にアップデート通知等の追加テキストを出力すると、PowerShell の `$token = & bw unlock --raw` がマルチライン配列を捕捉する。`$env:BW_SESSION = $token.Trim()` はこの配列を space-join した無効なセッションキーに設定するため、Go の `bw status` が常に "locked" を返し再アンロックループに陥っていた。

## 変更点

| ファイル | 変更内容 |
|---|---|
| `cmd/dsx/env.go` | `ensureBitwardenSessionFunc` 変数を削除、`runEnvExport` を `getEnvVarsFunc()` 一本化 + `os.Getenv("BW_SESSION")` でトークン取得に変更 |
| `cmd/dsx/env_test.go` | テストを新しい設計に合わせて更新 (`t.Setenv("BW_SESSION", ...)` 使用) |
| `cmd/dsx/config.go` | `getPowerShellScript()` の `dsx-unlock` を `$rawOutput = @(& bw unlock --raw)` + 最後の非空行抽出に変更 |
| `cmd/dsx/config_test.go` | 生成スクリプトのテストフレーズを更新 |
| `~/.config/dsx/init.ps1` | インストール済みスクリプトに同修正を直接適用 |

## Test plan

- [x] `go test ./...` 全件パス（lint/test pre-push hook 通過）
- [ ] `dsx-run` 実機動作確認（BW_SESSION 未設定状態からパスワード入力1回で完了すること）

Closes #70 相当（v0.6.1 で修正されなかった問題の再修正）

🤖 Generated with [Claude Code](https://claude.com/claude-code)