### PR TITLE
fix: bw コマンドの stdout 混入通知による JSON パース失敗とトークン破損を修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@
 
 ## [Unreleased]
 
+## [v0.6.3] - 2026-05-20
+
+### Fixed
+
+- `runBWUnlockRaw` (Go 側) が `bw unlock --raw` のマルチライン出力（アップデート通知等が stdout に混入する場合）を正しく処理できず、無効な `BW_SESSION` が設定される問題を修正（最後の非空行のみをセッショントークンとして使用するよう変更。PowerShell `dsx-unlock` の PR #70 修正と同様のパターンを Go 側にも適用）
+- `getBitwardenStatus` が `bw status` の stdout にアップデート通知が混入した場合に JSON パースに失敗し、有効な `BW_SESSION` があるにもかかわらず「ロック済み」と誤判断して再アンロックを引き起こす問題を修正（`{` 以降の JSON 部分のみを解析）
+- `listBitwardenEnvItems` が `bw list items` の stdout にアップデート通知が混入した場合に JSON パースに失敗する問題を修正（`[` 以降の JSON 部分のみを解析）
+
 ## [v0.6.2] - 2026-05-19
 
 ### Fixed

--- a/internal/secret/bitwarden.go
+++ b/internal/secret/bitwarden.go
@@ -1,6 +1,7 @@
 package secret
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -66,7 +67,16 @@ func runBWUnlockRaw() (string, error) {
 		return "", fmt.Errorf("bw unlock が失敗しました: %w", err)
 	}
 
-	return strings.TrimSpace(string(output)), nil
+	// アップデート通知等が stdout に混入する場合があるため、
+	// 最後の非空行のみをセッショントークンとして使用する（PowerShell 側と同様）
+	lines := strings.Split(strings.TrimSpace(string(output)), "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		if line := strings.TrimSpace(lines[i]); line != "" {
+			return line, nil
+		}
+	}
+
+	return "", nil
 }
 
 // debugLog はデバッグログを出力します。DSX_DEBUG=1 で有効化されます。
@@ -323,6 +333,12 @@ func listBitwardenEnvItems() ([]BitwardenItem, error) {
 		return nil, fmt.Errorf("bw list items が失敗しました: %w", err)
 	}
 
+	// アップデート通知等が stdout に混入する場合を考慮して、
+	// '[' 以降の JSON 配列部分のみを解析する
+	if idx := bytes.IndexByte(output, '['); idx > 0 {
+		output = output[idx:]
+	}
+
 	var items []BitwardenItem
 	if err := json.Unmarshal(output, &items); err != nil {
 		return nil, fmt.Errorf("JSON のパースに失敗しました: %w", err)
@@ -558,6 +574,12 @@ func getBitwardenStatus() (string, error) {
 	output, err := cmd.Output()
 	if err != nil {
 		return "", err
+	}
+
+	// アップデート通知等が stdout に混入する場合を考慮して、
+	// '{' 以降の JSON オブジェクト部分のみを解析する
+	if idx := bytes.IndexByte(output, '{'); idx > 0 {
+		output = output[idx:]
 	}
 
 	var status BitwardenStatus

--- a/tasks.md
+++ b/tasks.md
@@ -54,9 +54,9 @@
 - [x] README.md: バージョン表記を v0.6.1 に更新
 - [x] `task check` 実機確認（fmt/vet/test/lint）
 - [x] PR 作成（PR #69）
-- [ ] PR マージ
-- [ ] `v0.6.1` タグ発行・push → goreleaser が GitHub Release を自動作成
-- [ ] GitHub Release ページを見やすく編集
+- [x] PR マージ
+- [x] `v0.6.1` タグ発行・push → goreleaser が GitHub Release を自動作成
+- [x] GitHub Release ページを見やすく編集
 
 ---
 


### PR DESCRIPTION
## Summary

- `runBWUnlockRaw` が `bw unlock --raw` の stdout にアップデート通知が混入した場合、`strings.TrimSpace` だけでは複数行のままトークンに設定され、無効な `BW_SESSION` が `os.Setenv` されていた問題を修正。最後の非空行のみをトークンとして使用するよう変更（PowerShell `dsx-unlock` の PR #70 修正と同パターンを Go 側に適用）
- `getBitwardenStatus` が `bw status` の stdout に通知が混入すると JSON パースが失敗し、有効な `BW_SESSION` を「ロック済み」と誤判断して再アンロードを引き起こしていた問題を修正（`{` 以降のみを JSON として解析）
- `listBitwardenEnvItems` が `bw list items` の stdout に通知が混入すると JSON パースが失敗し `unexpected end of JSON input` になっていた問題を修正（`[` 以降のみを JSON として解析）

### 根本原因

PR #70 では PowerShell 側の `dsx-unlock` に同様の修正を適用したが、Go 側の `runBWUnlockRaw` は未修正のままだった。`bw` CLI がアップデート通知を stdout に出力する場合、Go 側でも同様にトークンが破損し、以下の連鎖が発生していた：

1. 無効な `BW_SESSION` が設定される
2. `getBitwardenStatus` が JSON パース失敗でエラーを返す → 「ロック済み」と誤判断して再アンロード
3. 再アンロード後の `bw list items` がセッション無効のため空 stdout を返す → `unexpected end of JSON input`

## Test plan

- [ ] `go test ./internal/secret/...` が通ること（CI で確認済み）
- [ ] `dsx-run` を実行してパスワード入力が1回のみで完了すること
- [ ] `dsx env export` が正常にシェル変数を出力すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)