### PR TITLE
chore: close v0.6.3 release tasks in tasks.md

### DIFF
--- a/tasks.md
+++ b/tasks.md
@@ -208,9 +208,9 @@
 - [x] PR #71 マージ（bw stdout 混入対応・JSON パース堅牢化）
 - [x] CHANGELOG.md: v0.6.3 セクション確認（2026-05-20）
 - [x] README.md: バージョン表記を v0.6.3 に更新
-- [ ] PR 作成・マージ
-- [ ] `v0.6.3` タグ発行・push → goreleaser が GitHub Release を自動作成
-- [ ] GitHub Release ページを見やすく編集
+- [x] PR 作成・マージ
+- [x] `v0.6.3` タグ発行・push → goreleaser が GitHub Release を自動作成
+- [x] GitHub Release ページを見やすく編集
 
 ---
 


### PR DESCRIPTION
## Summary
- v0.6.3 リリース作業（PR 作成・マージ、タグ発行・push、GitHub Release 編集）を `tasks.md` で完了済みに更新

## Test plan
- [ ] `tasks.md` の完了マークが正しいか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)