### PR TITLE
fix(sys/cargo): cargo-update 未インストール時に自動インストールし全件再ビルドを解消

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- `dsx sys update` の cargo 更新処理で `cargo-update` が未インストールの場合に全パッケージを `cargo install --force` で強制再ビルドしていた問題を修正。`cargo-update` がなければ自動インストールし、`cargo install-update -a`（更新必要分のみ再ビルド）を使用するよう変更（#74）
+
 ## [v0.6.3] - 2026-05-20
 
 ### Fixed

--- a/internal/updater/cargo.go
+++ b/internal/updater/cargo.go
@@ -157,7 +157,7 @@ func cargoInstallUpdateBinPath() (string, error) {
 
 	// 実行可能ファイルの候補（Windows では .exe/.cmd/.bat も確認）
 	candidates := []string{"cargo-install-update"}
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == windowsOS {
 		candidates = []string{
 			"cargo-install-update.exe",
 			"cargo-install-update.cmd",

--- a/internal/updater/cargo.go
+++ b/internal/updater/cargo.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/scottlz0310/dsx/internal/config"
@@ -80,13 +82,14 @@ func (c *CargoUpdater) Update(ctx context.Context, opts UpdateOptions) (*UpdateR
 		return result, nil
 	}
 
-	// cargo-update がなければ自動インストール
-	if err := c.ensureCargoUpdate(ctx); err != nil {
+	// cargo-update がなければ自動インストール、フルパスを取得
+	updateBin, err := c.ensureCargoUpdate(ctx)
+	if err != nil {
 		return result, err
 	}
 
-	// cargo install-update -a で更新（更新不要なパッケージは自動スキップ）
-	cmd := exec.CommandContext(ctx, "cargo", "install-update", "-a")
+	// フルパスで直接実行（PATH に ~/.cargo/bin がない環境でも動作）
+	cmd := exec.CommandContext(ctx, updateBin, "-a")
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.Stdin = os.Stdin
@@ -102,10 +105,11 @@ func (c *CargoUpdater) Update(ctx context.Context, opts UpdateOptions) (*UpdateR
 	return result, nil
 }
 
-// ensureCargoUpdate は cargo-update がなければ自動インストールします。
-func (c *CargoUpdater) ensureCargoUpdate(ctx context.Context) error {
-	if _, err := exec.LookPath("cargo-install-update"); err == nil {
-		return nil
+// ensureCargoUpdate は cargo-update がなければ自動インストールし、
+// cargo-install-update のフルパスを返します。
+func (c *CargoUpdater) ensureCargoUpdate(ctx context.Context) (string, error) {
+	if path, err := exec.LookPath("cargo-install-update"); err == nil {
+		return path, nil
 	}
 
 	fmt.Println("ℹ️  cargo-update が見つかりません。自動インストールします...")
@@ -115,12 +119,60 @@ func (c *CargoUpdater) ensureCargoUpdate(ctx context.Context) error {
 	cmd.Stderr = os.Stderr
 
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("cargo-update のインストールに失敗: %w", err)
+		return "", fmt.Errorf("cargo-update のインストールに失敗: %w", err)
 	}
 
 	fmt.Println("✅ cargo-update のインストールが完了しました。")
 
-	return nil
+	// PATH への反映を再確認
+	if path, err := exec.LookPath("cargo-install-update"); err == nil {
+		return path, nil
+	}
+
+	// PATH に反映されていない場合は CARGO_HOME/bin を直接確認
+	path, err := cargoInstallUpdateBinPath()
+	if err != nil {
+		return "", fmt.Errorf(
+			"cargo-update のインストールは成功しましたが、cargo-install-update が PATH に見つかりません。"+
+				"~/.cargo/bin を PATH に追加してから再実行してください: %w", err)
+	}
+
+	return path, nil
+}
+
+// cargoInstallUpdateBinPath は CARGO_HOME/bin の cargo-install-update のパスを返します。
+// PATH に ~/.cargo/bin が含まれていない環境での自動インストール後のフォールバックに使用します。
+func cargoInstallUpdateBinPath() (string, error) {
+	cargoHome := os.Getenv("CARGO_HOME")
+	if cargoHome == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+
+		cargoHome = filepath.Join(home, ".cargo")
+	}
+
+	binDir := filepath.Join(cargoHome, "bin")
+
+	// 実行可能ファイルの候補（Windows では .exe/.cmd/.bat も確認）
+	candidates := []string{"cargo-install-update"}
+	if runtime.GOOS == "windows" {
+		candidates = []string{
+			"cargo-install-update.exe",
+			"cargo-install-update.cmd",
+			"cargo-install-update.bat",
+		}
+	}
+
+	for _, name := range candidates {
+		path := filepath.Join(binDir, name)
+		if _, err := os.Stat(path); err == nil {
+			return path, nil
+		}
+	}
+
+	return "", fmt.Errorf("%s に cargo-install-update が見つかりません", binDir)
 }
 
 // parseInstallList は "cargo install --list" の出力をパースします

--- a/internal/updater/cargo.go
+++ b/internal/updater/cargo.go
@@ -80,51 +80,47 @@ func (c *CargoUpdater) Update(ctx context.Context, opts UpdateOptions) (*UpdateR
 		return result, nil
 	}
 
-	// cargo-update がインストールされているか確認
-	// cargo-update は cargo のサブコマンドとして動作するため、
-	// cargo install-update --help で確認
-	checkCmd := exec.CommandContext(ctx, "cargo", "install-update", "--help")
-	if err := checkCmd.Run(); err == nil {
-		// cargo-update を使用（推奨）
-		cmd := exec.CommandContext(ctx, "cargo", "install-update", "-a")
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
-		cmd.Stdin = os.Stdin
+	// cargo-update がなければ自動インストール
+	if err := c.ensureCargoUpdate(ctx); err != nil {
+		return result, err
+	}
 
-		if err := cmd.Run(); err != nil {
-			result.Errors = append(result.Errors, err)
-			return result, fmt.Errorf("cargo install-update -a に失敗: %w", err)
-		}
-	} else {
-		// cargo-update がない場合は個別に再インストール
-		for _, pkg := range checkResult.Packages {
-			cmd := exec.CommandContext(ctx, "cargo", "install", "--force", pkg.Name)
-			cmd.Stdout = os.Stdout
-			cmd.Stderr = os.Stderr
-			cmd.Stdin = os.Stdin
+	// cargo install-update -a で更新（更新不要なパッケージは自動スキップ）
+	cmd := exec.CommandContext(ctx, "cargo", "install-update", "-a")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Stdin = os.Stdin
 
-			if err := cmd.Run(); err != nil {
-				result.FailedCount++
-				result.Errors = append(result.Errors, fmt.Errorf("%s: %w", pkg.Name, err))
-
-				continue
-			}
-
-			result.UpdatedCount++
-		}
-
-		if len(result.Errors) > 0 {
-			result.Packages = checkResult.Packages
-			result.Message = fmt.Sprintf("%d 件更新、%d 件失敗", result.UpdatedCount, result.FailedCount)
-
-			return result, fmt.Errorf("一部のパッケージ更新に失敗しました")
-		}
+	if err := cmd.Run(); err != nil {
+		result.Errors = append(result.Errors, err)
+		return result, fmt.Errorf("cargo install-update -a に失敗: %w", err)
 	}
 
 	result.Packages = checkResult.Packages
-	result.Message = fmt.Sprintf("%d 件のパッケージを確認・更新しました", result.UpdatedCount)
+	result.Message = fmt.Sprintf("%d 件のパッケージを確認・更新しました", len(checkResult.Packages))
 
 	return result, nil
+}
+
+// ensureCargoUpdate は cargo-update がなければ自動インストールします。
+func (c *CargoUpdater) ensureCargoUpdate(ctx context.Context) error {
+	if _, err := exec.LookPath("cargo-install-update"); err == nil {
+		return nil
+	}
+
+	fmt.Println("ℹ️  cargo-update が見つかりません。自動インストールします...")
+
+	cmd := exec.CommandContext(ctx, "cargo", "install", "cargo-update")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("cargo-update のインストールに失敗: %w", err)
+	}
+
+	fmt.Println("✅ cargo-update のインストールが完了しました。")
+
+	return nil
 }
 
 // parseInstallList は "cargo install --list" の出力をパースします

--- a/internal/updater/cargo_test.go
+++ b/internal/updater/cargo_test.go
@@ -146,6 +146,7 @@ func TestCargoUpdater_Update(t *testing.T) {
 		name        string
 		mode        string
 		noUpdate    bool // true: cargo-install-update バイナリを PATH に含めない
+		noCargoBin  bool // true: CARGO_HOME/bin にもバイナリを配置しない（フォールバック失敗のテスト用）
 		opts        UpdateOptions
 		wantErr     bool
 		errContains string
@@ -195,6 +196,15 @@ func TestCargoUpdater_Update(t *testing.T) {
 			wantErr:     true,
 			errContains: "cargo-update のインストールに失敗",
 		},
+		{
+			name:        "cargo-update 未インストール → 自動インストール成功 → PATH にも CARGO_HOME にも見つからない",
+			mode:        "updates",
+			noUpdate:    true,
+			noCargoBin:  true,
+			opts:        UpdateOptions{},
+			wantErr:     true,
+			errContains: "PATH に見つかりません",
+		},
 	}
 
 	for _, tc := range testCases {
@@ -209,7 +219,9 @@ func TestCargoUpdater_Update(t *testing.T) {
 			// CARGO_HOME/bin にダミーバイナリを配置する（cargo install 後の状態をシミュレート）。
 			if tc.noUpdate {
 				cargoHomeDir := filepath.Join(fakeDir, "cargo_home")
-				writeFakeCIUBinary(t, filepath.Join(cargoHomeDir, "bin"))
+				if !tc.noCargoBin {
+					writeFakeCIUBinary(t, filepath.Join(cargoHomeDir, "bin"))
+				}
 				t.Setenv("CARGO_HOME", cargoHomeDir)
 				t.Setenv("PATH", fakeDir)
 			} else {

--- a/internal/updater/cargo_test.go
+++ b/internal/updater/cargo_test.go
@@ -145,6 +145,7 @@ func TestCargoUpdater_Update(t *testing.T) {
 	testCases := []struct {
 		name        string
 		mode        string
+		noUpdate    bool // true: cargo-install-update バイナリを PATH に含めない
 		opts        UpdateOptions
 		wantErr     bool
 		errContains string
@@ -178,15 +179,37 @@ func TestCargoUpdater_Update(t *testing.T) {
 			wantErr:     true,
 			errContains: "cargo install-update -a に失敗",
 		},
+		{
+			name:        "cargo-update 未インストール → 自動インストール → 更新成功",
+			mode:        "updates",
+			noUpdate:    true,
+			opts:        UpdateOptions{},
+			wantErr:     false,
+			msgContains: "確認・更新しました",
+		},
+		{
+			name:        "cargo-update 未インストール → 自動インストール失敗",
+			mode:        "install_update_error",
+			noUpdate:    true,
+			opts:        UpdateOptions{},
+			wantErr:     true,
+			errContains: "cargo-update のインストールに失敗",
+		},
 	}
 
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			fakeDir := t.TempDir()
-			writeFakeCargoCommand(t, fakeDir)
+			writeFakeCargoCommandImpl(t, fakeDir, !tc.noUpdate)
 
-			t.Setenv("PATH", fakeDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+			// noUpdate=true の場合は PATH を fakeDir のみに絞り、
+			// 実環境の cargo-install-update が LookPath に引っかからないようにする
+			if tc.noUpdate {
+				t.Setenv("PATH", fakeDir)
+			} else {
+				t.Setenv("PATH", fakeDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+			}
 			t.Setenv("DSX_TEST_CARGO_MODE", tc.mode)
 
 			c := &CargoUpdater{}
@@ -214,9 +237,15 @@ func TestCargoUpdater_Update(t *testing.T) {
 
 func writeFakeCargoCommand(t *testing.T, dir string) {
 	t.Helper()
+	writeFakeCargoCommandImpl(t, dir, true)
+}
+
+// writeFakeCargoCommandImpl は fake cargo コマンドを作成します。
+// withUpdate が false の場合、cargo-install-update バイナリを作成しません（LookPath が失敗する）。
+func writeFakeCargoCommandImpl(t *testing.T, dir string, withUpdate bool) {
+	t.Helper()
 
 	if runtime.GOOS == "windows" {
-		// fake cargo.cmd
 		cargoContent := `@echo off
 set mode=%DSX_TEST_CARGO_MODE%
 if "%1"=="install" goto doinstall
@@ -226,6 +255,7 @@ exit /b 1
 :doinstall
 if "%2"=="--list" goto dolist
 if "%2"=="--force" goto doforce
+if "%2"=="cargo-update" goto doinstallcargoupdate
 echo invalid args 1>&2
 exit /b 1
 :dolist
@@ -243,8 +273,13 @@ echo     bat
 exit /b 0
 :doforce
 exit /b 0
+:doinstallcargoupdate
+if "%mode%"=="install_update_error" (
+  echo cargo install cargo-update failed 1>&2
+  exit /b 1
+)
+exit /b 0
 :doinstallupdate
-if "%2"=="--help" exit /b 0
 if "%2"=="-a" goto doupdate
 echo invalid args 1>&2
 exit /b 1
@@ -261,17 +296,16 @@ exit /b 0
 			t.Fatalf("fake cargo command write failed: %v", err)
 		}
 
-		// fake cargo-install-update.cmd（LookPath 用）
-		updateContent := `@echo off
-exit /b 0
-`
+		if !withUpdate {
+			return
+		}
 
+		updateContent := "@echo off\r\nexit /b 0\r\n"
 		updatePath := filepath.Join(dir, "cargo-install-update.cmd")
 		if err := os.WriteFile(updatePath, []byte(updateContent), 0o755); err != nil {
 			t.Fatalf("fake cargo-install-update command write failed: %v", err)
 		}
 	} else {
-		// fake cargo
 		cargoContent := `#!/bin/sh
 mode="${DSX_TEST_CARGO_MODE}"
 case "$1" in
@@ -294,6 +328,13 @@ case "$1" in
       --force)
         exit 0
         ;;
+      cargo-update)
+        if [ "${mode}" = "install_update_error" ]; then
+          echo "cargo install cargo-update failed" 1>&2
+          exit 1
+        fi
+        exit 0
+        ;;
       *)
         echo "invalid args" 1>&2
         exit 1
@@ -302,9 +343,6 @@ case "$1" in
     ;;
   install-update)
     case "$2" in
-      --help)
-        exit 0
-        ;;
       -a)
         if [ "${mode}" = "update_error" ]; then
           echo "cargo install-update failed" 1>&2
@@ -334,11 +372,11 @@ esac
 			t.Fatalf("fake cargo command chmod failed: %v", err)
 		}
 
-		// fake cargo-install-update（LookPath 用）
-		updateContent := `#!/bin/sh
-exit 0
-`
+		if !withUpdate {
+			return
+		}
 
+		updateContent := "#!/bin/sh\nexit 0\n"
 		updatePath := filepath.Join(dir, "cargo-install-update")
 		if err := os.WriteFile(updatePath, []byte(updateContent), 0o755); err != nil {
 			t.Fatalf("fake cargo-install-update command write failed: %v", err)

--- a/internal/updater/cargo_test.go
+++ b/internal/updater/cargo_test.go
@@ -210,6 +210,7 @@ func TestCargoUpdater_Update(t *testing.T) {
 			} else {
 				t.Setenv("PATH", fakeDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 			}
+
 			t.Setenv("DSX_TEST_CARGO_MODE", tc.mode)
 
 			c := &CargoUpdater{}
@@ -301,6 +302,7 @@ exit /b 0
 		}
 
 		updateContent := "@echo off\r\nexit /b 0\r\n"
+
 		updatePath := filepath.Join(dir, "cargo-install-update.cmd")
 		if err := os.WriteFile(updatePath, []byte(updateContent), 0o755); err != nil {
 			t.Fatalf("fake cargo-install-update command write failed: %v", err)
@@ -377,6 +379,7 @@ esac
 		}
 
 		updateContent := "#!/bin/sh\nexit 0\n"
+
 		updatePath := filepath.Join(dir, "cargo-install-update")
 		if err := os.WriteFile(updatePath, []byte(updateContent), 0o755); err != nil {
 			t.Fatalf("fake cargo-install-update command write failed: %v", err)

--- a/internal/updater/cargo_test.go
+++ b/internal/updater/cargo_test.go
@@ -222,6 +222,7 @@ func TestCargoUpdater_Update(t *testing.T) {
 				if !tc.noCargoBin {
 					writeFakeCIUBinary(t, filepath.Join(cargoHomeDir, "bin"))
 				}
+
 				t.Setenv("CARGO_HOME", cargoHomeDir)
 				t.Setenv("PATH", fakeDir)
 			} else {

--- a/internal/updater/cargo_test.go
+++ b/internal/updater/cargo_test.go
@@ -204,8 +204,13 @@ func TestCargoUpdater_Update(t *testing.T) {
 			writeFakeCargoCommandImpl(t, fakeDir, !tc.noUpdate)
 
 			// noUpdate=true の場合は PATH を fakeDir のみに絞り、
-			// 実環境の cargo-install-update が LookPath に引っかからないようにする
+			// 実環境の cargo-install-update が LookPath に引っかからないようにする。
+			// また CARGO_HOME を設定して cargoInstallUpdateBinPath のフォールバックが機能するよう
+			// CARGO_HOME/bin にダミーバイナリを配置する（cargo install 後の状態をシミュレート）。
 			if tc.noUpdate {
+				cargoHomeDir := filepath.Join(fakeDir, "cargo_home")
+				writeFakeCIUBinary(t, filepath.Join(cargoHomeDir, "bin"))
+				t.Setenv("CARGO_HOME", cargoHomeDir)
 				t.Setenv("PATH", fakeDir)
 			} else {
 				t.Setenv("PATH", fakeDir+string(os.PathListSeparator)+os.Getenv("PATH"))
@@ -301,7 +306,7 @@ exit /b 0
 			return
 		}
 
-		updateContent := "@echo off\r\nexit /b 0\r\n"
+		updateContent := "@echo off\r\nset mode=%DSX_TEST_CARGO_MODE%\r\nif \"%1\"==\"-a\" goto doupdate\r\necho invalid args 1>&2\r\nexit /b 1\r\n:doupdate\r\nif \"%mode%\"==\"update_error\" (\r\n  echo cargo install-update failed 1>&2\r\n  exit /b 1\r\n)\r\nexit /b 0\r\n"
 
 		updatePath := filepath.Join(dir, "cargo-install-update.cmd")
 		if err := os.WriteFile(updatePath, []byte(updateContent), 0o755); err != nil {
@@ -378,7 +383,7 @@ esac
 			return
 		}
 
-		updateContent := "#!/bin/sh\nexit 0\n"
+		updateContent := "#!/bin/sh\nmode=\"${DSX_TEST_CARGO_MODE}\"\ncase \"$1\" in\n  -a)\n    if [ \"${mode}\" = \"update_error\" ]; then\n      echo \"cargo install-update failed\" 1>&2\n      exit 1\n    fi\n    exit 0\n    ;;\n  *)\n    echo \"invalid args\" 1>&2\n    exit 1\n    ;;\nesac\n"
 
 		updatePath := filepath.Join(dir, "cargo-install-update")
 		if err := os.WriteFile(updatePath, []byte(updateContent), 0o755); err != nil {
@@ -387,6 +392,36 @@ esac
 
 		if err := os.Chmod(updatePath, 0o755); err != nil {
 			t.Fatalf("fake cargo-install-update command chmod failed: %v", err)
+		}
+	}
+}
+
+// writeFakeCIUBinary は指定ディレクトリに fake cargo-install-update バイナリを作成します。
+// noUpdate=true のテストで CARGO_HOME/bin へのフォールバックを検証するために使用します。
+func writeFakeCIUBinary(t *testing.T, dir string) {
+	t.Helper()
+
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("dir creation failed: %v", err)
+	}
+
+	if runtime.GOOS == "windows" {
+		content := "@echo off\r\nexit /b 0\r\n"
+		path := filepath.Join(dir, "cargo-install-update.cmd")
+
+		if err := os.WriteFile(path, []byte(content), 0o755); err != nil {
+			t.Fatalf("fake cargo-install-update.cmd write failed: %v", err)
+		}
+	} else {
+		content := "#!/bin/sh\nexit 0\n"
+		path := filepath.Join(dir, "cargo-install-update")
+
+		if err := os.WriteFile(path, []byte(content), 0o755); err != nil {
+			t.Fatalf("fake cargo-install-update write failed: %v", err)
+		}
+
+		if err := os.Chmod(path, 0o755); err != nil {
+			t.Fatalf("fake cargo-install-update chmod failed: %v", err)
 		}
 	}
 }

--- a/tasks.md
+++ b/tasks.md
@@ -214,6 +214,30 @@
 
 ---
 
+## Issue #74: cargo 更新パフォーマンス最適化
+
+### Phase 1: cargo-update 自動インストール（対応中）
+
+- [x] `internal/updater/cargo.go`: cargo-update 未インストール時に `cargo install cargo-update` で自動インストールし `cargo install-update -a` 経路に統一
+- [x] `internal/updater/cargo_test.go`: 自動インストール成功・失敗テストケース追加
+- [x] `CHANGELOG.md` 更新
+- [ ] PR 作成・マージ
+
+### Phase 2: Check() 事前実行のスキップ
+
+- [ ] cargo-update 経路では `cargo install --list` を省略
+
+### Phase 3: UpdatedCount 表示バグ修正
+
+- [ ] `cargo install-update -a` の出力パース or `len(checkResult.Packages)` 使用
+
+### Phase 4: 細部の整理
+
+- [ ] `exec.LookPath` への変更（Phase 1 で実施済み）
+- [ ] `cmd.Stdin` 接続の見直し
+
+---
+
 ## Backlog / 改善候補
 
 ### `AutoStash` オプションの修正（設定が機能していないバグ）


### PR DESCRIPTION
## 概要

`dsx sys update` の cargo 更新処理で、`cargo-update` が未インストールの場合に全インストール済みパッケージを `cargo install --force` で強制再ビルドしていた問題を修正。

実測で **647 件のクレートが毎回コンパイル**されており、数分単位の時間を浪費していた。

Closes #74 (Phase 1)

## 変更内容

### `internal/updater/cargo.go`

- `ensureCargoUpdate()` を追加: `exec.LookPath("cargo-install-update")` で存在確認し、未インストールなら `cargo install cargo-update` を自動実行
- 全件 `--force` 再インストールの分岐を削除し `cargo install-update -a` に統一（更新不要パッケージは自動スキップ）
- cargo-update の存在確認を `cargo install-update --help` 起動から `exec.LookPath` に変更

### `internal/updater/cargo_test.go`

- `writeFakeCargoCommand` を `writeFakeCargoCommandImpl(withUpdate bool)` に統合
- fake cargo に `cargo install cargo-update` サポートを追加
- テストケース追加:
  - `cargo-update 未インストール → 自動インストール → 更新成功`
  - `cargo-update 未インストール → 自動インストール失敗`

## 期待効果

| 状況 | 変更前 | 変更後 |
|------|--------|--------|
| 定常運用（更新なし） | 647 件を毎回再コンパイル（数分） | 更新なし → ほぼ即時 |
| 一部更新あり | 全件再コンパイル | 更新対象のみ |
| cargo-update 未インストール | 全件再コンパイル | 自動インストール後に差分更新 |

## テスト計画

- [x] `go test ./internal/updater/... -run TestCargo` 全件 PASS
- [x] `go test ./...` 全件 PASS
- [x] `go vet ./...` PASS
- [x] lint (golangci-lint) 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)