### PR TITLE
perf(sys/cargo): Check() 事前実行を省略し cargo install --list を削減

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ## [Unreleased]
 
+### Performance
+
+- `dsx sys update` の cargo 更新処理で `cargo install --list` の事前実行を省略。非 DryRun 時は `cargo install-update -a` を直接実行するよう変更し、起動時の余分な CLI 呼び出しを削減（#74）
+
 ### Fixed
 
 - `dsx sys update` の cargo 更新処理で `cargo-update` が未インストールの場合に全パッケージを `cargo install --force` で強制再ビルドしていた問題を修正。`cargo-update` がなければ自動インストールし、`cargo install-update -a`（更新必要分のみ再ビルド）を使用するよう変更（#74）

--- a/internal/updater/cargo.go
+++ b/internal/updater/cargo.go
@@ -64,18 +64,17 @@ func (c *CargoUpdater) Check(ctx context.Context) (*CheckResult, error) {
 func (c *CargoUpdater) Update(ctx context.Context, opts UpdateOptions) (*UpdateResult, error) {
 	result := &UpdateResult{}
 
-	// まず更新確認
-	checkResult, err := c.Check(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	if len(checkResult.Packages) == 0 {
-		result.Message = "cargo でインストールされたパッケージがありません"
-		return result, nil
-	}
-
 	if opts.DryRun {
+		checkResult, err := c.Check(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		if len(checkResult.Packages) == 0 {
+			result.Message = "cargo でインストールされたパッケージがありません"
+			return result, nil
+		}
+
 		result.Message = fmt.Sprintf("%d 件のインストール済みパッケージについて更新を確認します（DryRunモード）", len(checkResult.Packages))
 		result.Packages = checkResult.Packages
 
@@ -99,8 +98,7 @@ func (c *CargoUpdater) Update(ctx context.Context, opts UpdateOptions) (*UpdateR
 		return result, fmt.Errorf("cargo install-update -a に失敗: %w", err)
 	}
 
-	result.Packages = checkResult.Packages
-	result.Message = fmt.Sprintf("%d 件のパッケージを確認・更新しました", len(checkResult.Packages))
+	result.Message = "cargo パッケージを確認・更新しました"
 
 	return result, nil
 }

--- a/internal/updater/cargo_test.go
+++ b/internal/updater/cargo_test.go
@@ -160,9 +160,9 @@ func TestCargoUpdater_Update(t *testing.T) {
 			msgContains: "DryRunモード",
 		},
 		{
-			name:        "対象なし",
+			name:        "対象なし（DryRun）",
 			mode:        "none",
-			opts:        UpdateOptions{},
+			opts:        UpdateOptions{DryRun: true},
 			wantErr:     false,
 			msgContains: "パッケージがありません",
 		},

--- a/tasks.md
+++ b/tasks.md
@@ -216,16 +216,16 @@
 
 ## Issue #74: cargo 更新パフォーマンス最適化
 
-### Phase 1: cargo-update 自動インストール（対応中）
+### Phase 1: cargo-update 自動インストール（完了）
 
 - [x] `internal/updater/cargo.go`: cargo-update 未インストール時に `cargo install cargo-update` で自動インストールし `cargo install-update -a` 経路に統一
 - [x] `internal/updater/cargo_test.go`: 自動インストール成功・失敗テストケース追加
 - [x] `CHANGELOG.md` 更新
-- [ ] PR 作成・マージ
+- [x] PR #75 作成・マージ（359bdc2）
 
-### Phase 2: Check() 事前実行のスキップ
+### Phase 2: Check() 事前実行のスキップ（完了）
 
-- [ ] cargo-update 経路では `cargo install --list` を省略
+- [x] cargo-update 経路では `cargo install --list` を省略
 
 ### Phase 3: UpdatedCount 表示バグ修正
 


### PR DESCRIPTION
## 概要

Issue #74 Phase 2 の対応です。

- 非 DryRun 時に `cargo install --list`（Check()）を事前実行していた処理を削除
- `cargo install-update -a` を直接実行するよう変更
- DryRun 時のみ Check() を呼び出してインストール済みパッケージ一覧を取得

## 変更内容

### `internal/updater/cargo.go`

- `Update()` の冒頭にあった `c.Check(ctx)` の無条件呼び出しを削除
- `opts.DryRun` ブランチ内にのみ `Check()` を移動
- 成功メッセージを「cargo パッケージを確認・更新しました」に変更（件数カウント不要のため）

### `internal/updater/cargo_test.go`

- 「対象なし」テストケースを `DryRun: true` に変更し、`len(checkResult.Packages) == 0` パスのカバレッジを維持

## テスト

```
ok  github.com/scottlz0310/dsx/internal/updater  6.9s
```

Closes なし（Issue #74 Phase 2 完了）

🤖 Generated with [Claude Code](https://claude.com/claude-code)