### PR TITLE
perf(sys/cargo): 更新件数を cargo install-update 出力からパースして正確に計上

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Performance
 
+- `dsx sys update` の cargo 更新処理で `cargo install-update -a` の出力をパースして実際に更新されたパッケージ数を `UpdatedCount` に反映。「更新成功: N 件」の集計が正確になった（#74）
 - `dsx sys update` の cargo 更新処理で `cargo install --list` の事前実行を省略。非 DryRun 時は `cargo install-update -a` を直接実行するよう変更し、起動時の余分な CLI 呼び出しを削減（#74）
 
 ### Fixed

--- a/internal/updater/cargo.go
+++ b/internal/updater/cargo.go
@@ -1,8 +1,10 @@
 package updater
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -88,8 +90,10 @@ func (c *CargoUpdater) Update(ctx context.Context, opts UpdateOptions) (*UpdateR
 	}
 
 	// フルパスで直接実行（PATH に ~/.cargo/bin がない環境でも動作）
+	var buf bytes.Buffer
+
 	cmd := exec.CommandContext(ctx, updateBin, "-a")
-	cmd.Stdout = os.Stdout
+	cmd.Stdout = io.MultiWriter(os.Stdout, &buf)
 	cmd.Stderr = os.Stderr
 	cmd.Stdin = os.Stdin
 
@@ -98,7 +102,13 @@ func (c *CargoUpdater) Update(ctx context.Context, opts UpdateOptions) (*UpdateR
 		return result, fmt.Errorf("cargo install-update -a に失敗: %w", err)
 	}
 
-	result.Message = "cargo パッケージを確認・更新しました"
+	result.UpdatedCount = c.parseUpdateCount(buf.String())
+
+	if result.UpdatedCount > 0 {
+		result.Message = fmt.Sprintf("%d 件のパッケージを更新しました", result.UpdatedCount)
+	} else {
+		result.Message = "cargo パッケージを確認しました（更新なし）"
+	}
 
 	return result, nil
 }
@@ -171,6 +181,21 @@ func cargoInstallUpdateBinPath() (string, error) {
 	}
 
 	return "", fmt.Errorf("%s に cargo-install-update が見つかりません", binDir)
+}
+
+// parseUpdateCount は "cargo install-update -a" の出力から実際に更新されたパッケージ数を返します。
+// "pkg vX.Y.Z -> vA.B.C" 形式の行（バージョン遷移を示す " -> " を含む行）をカウントします。
+func (c *CargoUpdater) parseUpdateCount(output string) int {
+	output = strings.ReplaceAll(output, "\r\n", "\n")
+	count := 0
+
+	for _, line := range strings.Split(output, "\n") {
+		if strings.Contains(line, " -> ") {
+			count++
+		}
+	}
+
+	return count
 }
 
 // parseInstallList は "cargo install --list" の出力をパースします

--- a/internal/updater/cargo.go
+++ b/internal/updater/cargo.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 
 	"github.com/scottlz0310/dsx/internal/config"
@@ -184,18 +185,26 @@ func cargoInstallUpdateBinPath() (string, error) {
 }
 
 // parseUpdateCount は "cargo install-update -a" の出力から実際に更新されたパッケージ数を返します。
-// "pkg vX.Y.Z -> vA.B.C" 形式の行（バージョン遷移を示す " -> " を含む行）をカウントします。
+// 末尾のサマリ行 "Updated N package(s)." を解析します。
 func (c *CargoUpdater) parseUpdateCount(output string) int {
 	output = strings.ReplaceAll(output, "\r\n", "\n")
-	count := 0
 
 	for _, line := range strings.Split(output, "\n") {
-		if strings.Contains(line, " -> ") {
-			count++
+		line = strings.TrimSpace(line)
+
+		if !strings.HasPrefix(line, "Updated ") {
+			continue
+		}
+
+		parts := strings.Fields(line)
+		if len(parts) >= 2 {
+			if n, err := strconv.Atoi(parts[1]); err == nil {
+				return n
+			}
 		}
 	}
 
-	return count
+	return 0
 }
 
 // parseInstallList は "cargo install --list" の出力をパースします

--- a/internal/updater/cargo_test.go
+++ b/internal/updater/cargo_test.go
@@ -90,10 +90,12 @@ func TestCargoUpdater_parseUpdateCount(t *testing.T) {
 		expected int
 	}{
 		{name: "空の出力", output: "", expected: 0},
-		{name: "更新なし", output: "ripgrep v14.0.0\nbat v0.24.0\n", expected: 0},
-		{name: "1件更新", output: "ripgrep v14.0.0 -> v14.1.0\nbat v0.24.0\n", expected: 1},
-		{name: "2件更新", output: "ripgrep v14.0.0 -> v14.1.0\nbat v0.24.0 -> v0.25.0\n", expected: 2},
-		{name: "CRLF改行", output: "ripgrep v14.0.0 -> v14.1.0\r\nbat v0.24.0 -> v0.25.0\r\n", expected: 2},
+		{name: "更新なし（サマリなし）", output: "ripgrep - already at newest version\n", expected: 0},
+		{name: "1件更新", output: "Updated 1 package.\n", expected: 1},
+		{name: "2件更新", output: "Updated 2 packages.\n", expected: 2},
+		{name: "大きい数字", output: "Updated 10 packages.\n", expected: 10},
+		{name: "CRLF改行", output: "Updated 2 packages.\r\n", expected: 2},
+		{name: "テーブル付き出力", output: "  ripgrep  14.0.0  14.1.0  Yes\n  bat      0.24.0  0.24.0  No\nUpdated 1 package.\n", expected: 1},
 	}
 
 	for _, tt := range tests {
@@ -347,7 +349,7 @@ exit /b 0
 			return
 		}
 
-		updateContent := "@echo off\r\nset mode=%DSX_TEST_CARGO_MODE%\r\nif \"%1\"==\"-a\" goto doupdate\r\necho invalid args 1>&2\r\nexit /b 1\r\n:doupdate\r\nif \"%mode%\"==\"update_error\" (\r\n  echo cargo install-update failed 1>&2\r\n  exit /b 1\r\n)\r\nif \"%mode%\"==\"updates\" (\r\n  echo ripgrep v14.0.0 -^> v14.1.0\r\n  echo bat v0.24.0 -^> v0.25.0\r\n)\r\nexit /b 0\r\n"
+		updateContent := "@echo off\r\nset mode=%DSX_TEST_CARGO_MODE%\r\nif \"%1\"==\"-a\" goto doupdate\r\necho invalid args 1>&2\r\nexit /b 1\r\n:doupdate\r\nif \"%mode%\"==\"update_error\" (\r\n  echo cargo install-update failed 1>&2\r\n  exit /b 1\r\n)\r\nif \"%mode%\"==\"updates\" (\r\n  echo Updated 2 packages.\r\n)\r\nexit /b 0\r\n"
 
 		updatePath := filepath.Join(dir, "cargo-install-update.cmd")
 		if err := os.WriteFile(updatePath, []byte(updateContent), 0o755); err != nil {
@@ -424,7 +426,7 @@ esac
 			return
 		}
 
-		updateContent := "#!/bin/sh\nmode=\"${DSX_TEST_CARGO_MODE}\"\ncase \"$1\" in\n  -a)\n    if [ \"${mode}\" = \"update_error\" ]; then\n      echo \"cargo install-update failed\" 1>&2\n      exit 1\n    fi\n    if [ \"${mode}\" = \"updates\" ]; then\n      echo \"ripgrep v14.0.0 -> v14.1.0\"\n      echo \"bat v0.24.0 -> v0.25.0\"\n    fi\n    exit 0\n    ;;\n  *)\n    echo \"invalid args\" 1>&2\n    exit 1\n    ;;\nesac\n"
+		updateContent := "#!/bin/sh\nmode=\"${DSX_TEST_CARGO_MODE}\"\ncase \"$1\" in\n  -a)\n    if [ \"${mode}\" = \"update_error\" ]; then\n      echo \"cargo install-update failed\" 1>&2\n      exit 1\n    fi\n    if [ \"${mode}\" = \"updates\" ]; then\n      echo \"Updated 2 packages.\"\n    fi\n    exit 0\n    ;;\n  *)\n    echo \"invalid args\" 1>&2\n    exit 1\n    ;;\nesac\n"
 
 		updatePath := filepath.Join(dir, "cargo-install-update")
 		if err := os.WriteFile(updatePath, []byte(updateContent), 0o755); err != nil {
@@ -447,14 +449,14 @@ func writeFakeCIUBinary(t *testing.T, dir string) {
 	}
 
 	if runtime.GOOS == "windows" {
-		content := "@echo off\r\nset mode=%DSX_TEST_CARGO_MODE%\r\nif \"%1\"==\"-a\" goto doupdate\r\nexit /b 1\r\n:doupdate\r\nif \"%mode%\"==\"updates\" (\r\n  echo ripgrep v14.0.0 -^> v14.1.0\r\n  echo bat v0.24.0 -^> v0.25.0\r\n)\r\nexit /b 0\r\n"
+		content := "@echo off\r\nset mode=%DSX_TEST_CARGO_MODE%\r\nif \"%1\"==\"-a\" goto doupdate\r\nexit /b 1\r\n:doupdate\r\nif \"%mode%\"==\"updates\" (\r\n  echo Updated 2 packages.\r\n)\r\nexit /b 0\r\n"
 		path := filepath.Join(dir, "cargo-install-update.cmd")
 
 		if err := os.WriteFile(path, []byte(content), 0o755); err != nil {
 			t.Fatalf("fake cargo-install-update.cmd write failed: %v", err)
 		}
 	} else {
-		content := "#!/bin/sh\nmode=\"${DSX_TEST_CARGO_MODE}\"\ncase \"$1\" in\n  -a)\n    if [ \"${mode}\" = \"updates\" ]; then\n      echo \"ripgrep v14.0.0 -> v14.1.0\"\n      echo \"bat v0.24.0 -> v0.25.0\"\n    fi\n    exit 0\n    ;;\n  *)\n    exit 1\n    ;;\nesac\n"
+		content := "#!/bin/sh\nmode=\"${DSX_TEST_CARGO_MODE}\"\ncase \"$1\" in\n  -a)\n    if [ \"${mode}\" = \"updates\" ]; then\n      echo \"Updated 2 packages.\"\n    fi\n    exit 0\n    ;;\n  *)\n    exit 1\n    ;;\nesac\n"
 		path := filepath.Join(dir, "cargo-install-update")
 
 		if err := os.WriteFile(path, []byte(content), 0o755); err != nil {

--- a/internal/updater/cargo_test.go
+++ b/internal/updater/cargo_test.go
@@ -83,6 +83,27 @@ pkg 1.2.3:
 	}
 }
 
+func TestCargoUpdater_parseUpdateCount(t *testing.T) {
+	tests := []struct {
+		name     string
+		output   string
+		expected int
+	}{
+		{name: "空の出力", output: "", expected: 0},
+		{name: "更新なし", output: "ripgrep v14.0.0\nbat v0.24.0\n", expected: 0},
+		{name: "1件更新", output: "ripgrep v14.0.0 -> v14.1.0\nbat v0.24.0\n", expected: 1},
+		{name: "2件更新", output: "ripgrep v14.0.0 -> v14.1.0\nbat v0.24.0 -> v0.25.0\n", expected: 2},
+		{name: "CRLF改行", output: "ripgrep v14.0.0 -> v14.1.0\r\nbat v0.24.0 -> v0.25.0\r\n", expected: 2},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &CargoUpdater{}
+			assert.Equal(t, tt.expected, c.parseUpdateCount(tt.output))
+		})
+	}
+}
+
 func TestCargoUpdater_Check(t *testing.T) {
 	testCases := []struct {
 		name        string
@@ -151,6 +172,7 @@ func TestCargoUpdater_Update(t *testing.T) {
 		wantErr     bool
 		errContains string
 		msgContains string
+		wantUpdated int
 	}{
 		{
 			name:        "DryRunは更新せず計画表示",
@@ -171,7 +193,8 @@ func TestCargoUpdater_Update(t *testing.T) {
 			mode:        "updates",
 			opts:        UpdateOptions{},
 			wantErr:     false,
-			msgContains: "確認・更新しました",
+			msgContains: "件のパッケージを更新しました",
+			wantUpdated: 2,
 		},
 		{
 			name:        "更新失敗",
@@ -186,7 +209,8 @@ func TestCargoUpdater_Update(t *testing.T) {
 			noUpdate:    true,
 			opts:        UpdateOptions{},
 			wantErr:     false,
-			msgContains: "確認・更新しました",
+			msgContains: "件のパッケージを更新しました",
+			wantUpdated: 2,
 		},
 		{
 			name:        "cargo-update 未インストール → 自動インストール失敗",
@@ -249,6 +273,10 @@ func TestCargoUpdater_Update(t *testing.T) {
 
 			if tc.msgContains != "" {
 				assert.Contains(t, got.Message, tc.msgContains)
+			}
+
+			if !tc.opts.DryRun {
+				assert.Equal(t, tc.wantUpdated, got.UpdatedCount)
 			}
 		})
 	}
@@ -319,7 +347,7 @@ exit /b 0
 			return
 		}
 
-		updateContent := "@echo off\r\nset mode=%DSX_TEST_CARGO_MODE%\r\nif \"%1\"==\"-a\" goto doupdate\r\necho invalid args 1>&2\r\nexit /b 1\r\n:doupdate\r\nif \"%mode%\"==\"update_error\" (\r\n  echo cargo install-update failed 1>&2\r\n  exit /b 1\r\n)\r\nexit /b 0\r\n"
+		updateContent := "@echo off\r\nset mode=%DSX_TEST_CARGO_MODE%\r\nif \"%1\"==\"-a\" goto doupdate\r\necho invalid args 1>&2\r\nexit /b 1\r\n:doupdate\r\nif \"%mode%\"==\"update_error\" (\r\n  echo cargo install-update failed 1>&2\r\n  exit /b 1\r\n)\r\nif \"%mode%\"==\"updates\" (\r\n  echo ripgrep v14.0.0 -^> v14.1.0\r\n  echo bat v0.24.0 -^> v0.25.0\r\n)\r\nexit /b 0\r\n"
 
 		updatePath := filepath.Join(dir, "cargo-install-update.cmd")
 		if err := os.WriteFile(updatePath, []byte(updateContent), 0o755); err != nil {
@@ -396,7 +424,7 @@ esac
 			return
 		}
 
-		updateContent := "#!/bin/sh\nmode=\"${DSX_TEST_CARGO_MODE}\"\ncase \"$1\" in\n  -a)\n    if [ \"${mode}\" = \"update_error\" ]; then\n      echo \"cargo install-update failed\" 1>&2\n      exit 1\n    fi\n    exit 0\n    ;;\n  *)\n    echo \"invalid args\" 1>&2\n    exit 1\n    ;;\nesac\n"
+		updateContent := "#!/bin/sh\nmode=\"${DSX_TEST_CARGO_MODE}\"\ncase \"$1\" in\n  -a)\n    if [ \"${mode}\" = \"update_error\" ]; then\n      echo \"cargo install-update failed\" 1>&2\n      exit 1\n    fi\n    if [ \"${mode}\" = \"updates\" ]; then\n      echo \"ripgrep v14.0.0 -> v14.1.0\"\n      echo \"bat v0.24.0 -> v0.25.0\"\n    fi\n    exit 0\n    ;;\n  *)\n    echo \"invalid args\" 1>&2\n    exit 1\n    ;;\nesac\n"
 
 		updatePath := filepath.Join(dir, "cargo-install-update")
 		if err := os.WriteFile(updatePath, []byte(updateContent), 0o755); err != nil {
@@ -419,14 +447,14 @@ func writeFakeCIUBinary(t *testing.T, dir string) {
 	}
 
 	if runtime.GOOS == "windows" {
-		content := "@echo off\r\nexit /b 0\r\n"
+		content := "@echo off\r\nset mode=%DSX_TEST_CARGO_MODE%\r\nif \"%1\"==\"-a\" goto doupdate\r\nexit /b 1\r\n:doupdate\r\nif \"%mode%\"==\"updates\" (\r\n  echo ripgrep v14.0.0 -^> v14.1.0\r\n  echo bat v0.24.0 -^> v0.25.0\r\n)\r\nexit /b 0\r\n"
 		path := filepath.Join(dir, "cargo-install-update.cmd")
 
 		if err := os.WriteFile(path, []byte(content), 0o755); err != nil {
 			t.Fatalf("fake cargo-install-update.cmd write failed: %v", err)
 		}
 	} else {
-		content := "#!/bin/sh\nexit 0\n"
+		content := "#!/bin/sh\nmode=\"${DSX_TEST_CARGO_MODE}\"\ncase \"$1\" in\n  -a)\n    if [ \"${mode}\" = \"updates\" ]; then\n      echo \"ripgrep v14.0.0 -> v14.1.0\"\n      echo \"bat v0.24.0 -> v0.25.0\"\n    fi\n    exit 0\n    ;;\n  *)\n    exit 1\n    ;;\nesac\n"
 		path := filepath.Join(dir, "cargo-install-update")
 
 		if err := os.WriteFile(path, []byte(content), 0o755); err != nil {

--- a/tasks.md
+++ b/tasks.md
@@ -229,7 +229,7 @@
 
 ### Phase 3: UpdatedCount 表示バグ修正（完了）
 
-- [x] `cargo install-update -a` の出力をパースし、` -> ` を含む行を更新件数としてカウント
+- [x] `cargo install-update -a` の出力をパースし、`Updated N package(s).` サマリ行から更新件数を取得
 
 ### Phase 4: 細部の整理
 

--- a/tasks.md
+++ b/tasks.md
@@ -227,9 +227,9 @@
 
 - [x] cargo-update 経路では `cargo install --list` を省略
 
-### Phase 3: UpdatedCount 表示バグ修正
+### Phase 3: UpdatedCount 表示バグ修正（完了）
 
-- [ ] `cargo install-update -a` の出力パース or `len(checkResult.Packages)` 使用
+- [x] `cargo install-update -a` の出力をパースし、` -> ` を含む行を更新件数としてカウント
 
 ### Phase 4: 細部の整理
 


### PR DESCRIPTION
## 概要

Issue #74 Phase 3 の対応です。

`cargo install-update -a` の出力をパースして実際に更新されたパッケージ数を `UpdatedCount` に反映します。
これにより `dsx sys update` 実行後の「更新成功: N 件」サマリーが正確な更新数を表示するようになります。

## 変更内容

### `internal/updater/cargo.go`

- `bytes.Buffer` + `io.MultiWriter` で `cargo install-update -a` の stdout をキャプチャしつつターミナルにもリアルタイム表示
- `parseUpdateCount()` メソッドを追加: ` -> ` を含む行（バージョン遷移）をカウント
- 更新あり: `"%d 件のパッケージを更新しました"` / 更新なし: `"cargo パッケージを確認しました（更新なし）"`

### `internal/updater/cargo_test.go`

- フェイク `cargo-install-update` バイナリを mode `updates` 時に `ripgrep v14.0.0 -> v14.1.0` 形式の行を出力するよう更新
- `writeFakeCIUBinary` も同様に更新（CARGO_HOME/bin フォールバックパスのカバレッジ維持）
- `wantUpdated int` フィールドを追加し非 DryRun 成功ケースで `UpdatedCount` を検証
- `TestCargoUpdater_parseUpdateCount` を追加（5 ケース）

## テスト

```
ok  github.com/scottlz0310/dsx/internal/updater  7.3s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)