### PR TITLE
chore(sys/cargo): cmd.Stdin 削除・Phase 4 完了

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - `dsx sys update` の cargo 更新処理で `cargo install-update -a` の出力をパースして実際に更新されたパッケージ数を `UpdatedCount` に反映。「更新成功: N 件」の集計が正確になった（#74）
 - `dsx sys update` の cargo 更新処理で `cargo install --list` の事前実行を省略。非 DryRun 時は `cargo install-update -a` を直接実行するよう変更し、起動時の余分な CLI 呼び出しを削減（#74）
+- `cargo install-update -a` 実行時の `cmd.Stdin` 接続を削除。非対話コマンドへの不要な stdin 転送を除去（#74）
 
 ### Fixed
 

--- a/internal/updater/cargo.go
+++ b/internal/updater/cargo.go
@@ -96,7 +96,6 @@ func (c *CargoUpdater) Update(ctx context.Context, opts UpdateOptions) (*UpdateR
 	cmd := exec.CommandContext(ctx, updateBin, "-a")
 	cmd.Stdout = io.MultiWriter(os.Stdout, &buf)
 	cmd.Stderr = os.Stderr
-	cmd.Stdin = os.Stdin
 
 	if err := cmd.Run(); err != nil {
 		result.Errors = append(result.Errors, err)

--- a/tasks.md
+++ b/tasks.md
@@ -231,10 +231,10 @@
 
 - [x] `cargo install-update -a` の出力をパースし、`Updated N package(s).` サマリ行から更新件数を取得
 
-### Phase 4: 細部の整理
+### Phase 4: 細部の整理（完了）
 
-- [ ] `exec.LookPath` への変更（Phase 1 で実施済み）
-- [ ] `cmd.Stdin` 接続の見直し
+- [x] `exec.LookPath` への変更（Phase 1 で実施済み）
+- [x] `cmd.Stdin` 接続の削除（非対話コマンドのため不要）
 
 ---
 


### PR DESCRIPTION
## 概要

Issue #74 Phase 4（細部の整理）の対応です。

## 変更内容

### `internal/updater/cargo.go`

- `cargo install-update -a` 実行時の `cmd.Stdin = os.Stdin` を削除
  - 非対話コマンドへの stdin 転送は不要
  - CI・非対話環境でターミナルの stdin が誤って接続されるのを防ぐ

### `tasks.md`

- Phase 4 の 2 項目をクローズ（`exec.LookPath` は Phase 1 で実施済み）

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)