### PR TITLE
fix(sys/cargo): cargo-update v20 の API 変更に対応

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Fixed
 
+- `dsx sys update` の cargo 更新処理で `cargo-update v20+` の API 変更（`cargo-install-update -a` → `cargo-install-update install-update -a`）に対応。出力サマリ形式の変更（`Updated N...` → `Overall updated N...`）にも追従し、v19 との後方互換を維持
 - `dsx sys update` の cargo 更新処理で `cargo-update` が未インストールの場合に全パッケージを `cargo install --force` で強制再ビルドしていた問題を修正。`cargo-update` がなければ自動インストールし、`cargo install-update -a`（更新必要分のみ再ビルド）を使用するよう変更（#74）
 
 ## [v0.6.3] - 2026-05-20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 ### Fixed
 
-- `dsx sys update` の cargo 更新処理で `cargo-update v20+` の API 変更（`cargo-install-update -a` → `cargo-install-update install-update -a`）に対応。出力サマリ形式の変更（`Updated N...` → `Overall updated N...`）にも追従し、v19 との後方互換を維持
+- `dsx sys update` の cargo 更新処理で `cargo-update v20+` の API 変更に対応。バイナリの `--version` 出力でバージョンを自動検出し、v20+（サブコマンド形式 `install-update -a`）と v19-（直接引数 `-a`）を呼び分けることで後方互換を維持。出力サマリ形式（`Updated N...` → `Overall updated N...`）の変更にも追従
 - `dsx sys update` の cargo 更新処理で `cargo-update` が未インストールの場合に全パッケージを `cargo install --force` で強制再ビルドしていた問題を修正。`cargo-update` がなければ自動インストールし、`cargo install-update -a`（更新必要分のみ再ビルド）を使用するよう変更（#74）
 
 ## [v0.6.3] - 2026-05-20

--- a/internal/updater/cargo.go
+++ b/internal/updater/cargo.go
@@ -91,9 +91,10 @@ func (c *CargoUpdater) Update(ctx context.Context, opts UpdateOptions) (*UpdateR
 	}
 
 	// フルパスで直接実行（PATH に ~/.cargo/bin がない環境でも動作）
+	// v20 以降はサブコマンド形式: cargo-install-update install-update -a
 	var buf bytes.Buffer
 
-	cmd := exec.CommandContext(ctx, updateBin, "-a")
+	cmd := exec.CommandContext(ctx, updateBin, "install-update", "-a")
 	cmd.Stdout = io.MultiWriter(os.Stdout, &buf)
 	cmd.Stderr = os.Stderr
 
@@ -184,21 +185,30 @@ func cargoInstallUpdateBinPath() (string, error) {
 }
 
 // parseUpdateCount は "cargo install-update -a" の出力から実際に更新されたパッケージ数を返します。
-// 末尾のサマリ行 "Updated N package(s)." を解析します。
+// v20+: "Overall updated N package(s)." / v19-: "Updated N package(s)." のサマリ行を解析します。
 func (c *CargoUpdater) parseUpdateCount(output string) int {
 	output = strings.ReplaceAll(output, "\r\n", "\n")
 
 	for _, line := range strings.Split(output, "\n") {
 		line = strings.TrimSpace(line)
 
-		if !strings.HasPrefix(line, "Updated ") {
-			continue
+		// v20+: "Overall updated N package(s)."
+		if strings.HasPrefix(line, "Overall updated ") {
+			parts := strings.Fields(line)
+			if len(parts) >= 3 {
+				if n, err := strconv.Atoi(parts[2]); err == nil {
+					return n
+				}
+			}
 		}
 
-		parts := strings.Fields(line)
-		if len(parts) >= 2 {
-			if n, err := strconv.Atoi(parts[1]); err == nil {
-				return n
+		// v19-: "Updated N package(s)."
+		if strings.HasPrefix(line, "Updated ") {
+			parts := strings.Fields(line)
+			if len(parts) >= 2 {
+				if n, err := strconv.Atoi(parts[1]); err == nil {
+					return n
+				}
 			}
 		}
 	}

--- a/internal/updater/cargo.go
+++ b/internal/updater/cargo.go
@@ -91,10 +91,9 @@ func (c *CargoUpdater) Update(ctx context.Context, opts UpdateOptions) (*UpdateR
 	}
 
 	// フルパスで直接実行（PATH に ~/.cargo/bin がない環境でも動作）
-	// v20 以降はサブコマンド形式: cargo-install-update install-update -a
 	var buf bytes.Buffer
 
-	cmd := exec.CommandContext(ctx, updateBin, "install-update", "-a")
+	cmd := exec.CommandContext(ctx, updateBin, cargoUpdateArgs(updateBin)...)
 	cmd.Stdout = io.MultiWriter(os.Stdout, &buf)
 	cmd.Stderr = os.Stderr
 
@@ -147,6 +146,18 @@ func (c *CargoUpdater) ensureCargoUpdate(ctx context.Context) (string, error) {
 	}
 
 	return path, nil
+}
+
+// cargoUpdateArgs はインストール済みの cargo-update バージョンに応じた実行引数を返します。
+// v19-: --version が "cargo-install-update N.N.N" を返す → ["-a"]（直接引数形式）
+// v20+: --version が "cargo N.N.N" を返す、または検出失敗 → ["install-update", "-a"]（サブコマンド形式）
+func cargoUpdateArgs(bin string) []string {
+	out, err := exec.Command(bin, "--version").Output()
+	if err == nil && strings.HasPrefix(strings.TrimSpace(string(out)), "cargo-install-update") {
+		return []string{"-a"}
+	}
+
+	return []string{"install-update", "-a"}
 }
 
 // cargoInstallUpdateBinPath は CARGO_HOME/bin の cargo-install-update のパスを返します。

--- a/internal/updater/cargo.go
+++ b/internal/updater/cargo.go
@@ -152,7 +152,7 @@ func (c *CargoUpdater) ensureCargoUpdate(ctx context.Context) (string, error) {
 // v19-: --version が "cargo-install-update N.N.N" を返す → ["-a"]（直接引数形式）
 // v20+: --version が "cargo N.N.N" を返す、または検出失敗 → ["install-update", "-a"]（サブコマンド形式）
 func cargoUpdateArgs(bin string) []string {
-	out, err := exec.Command(bin, "--version").Output()
+	out, err := exec.CommandContext(context.Background(), bin, "--version").Output()
 	if err == nil && strings.HasPrefix(strings.TrimSpace(string(out)), "cargo-install-update") {
 		return []string{"-a"}
 	}

--- a/internal/updater/cargo_test.go
+++ b/internal/updater/cargo_test.go
@@ -89,13 +89,22 @@ func TestCargoUpdater_parseUpdateCount(t *testing.T) {
 		output   string
 		expected int
 	}{
+		// 共通
 		{name: "空の出力", output: "", expected: 0},
 		{name: "更新なし（サマリなし）", output: "ripgrep - already at newest version\n", expected: 0},
-		{name: "1件更新", output: "Updated 1 package.\n", expected: 1},
-		{name: "2件更新", output: "Updated 2 packages.\n", expected: 2},
-		{name: "大きい数字", output: "Updated 10 packages.\n", expected: 10},
-		{name: "CRLF改行", output: "Updated 2 packages.\r\n", expected: 2},
-		{name: "テーブル付き出力", output: "  ripgrep  14.0.0  14.1.0  Yes\n  bat      0.24.0  0.24.0  No\nUpdated 1 package.\n", expected: 1},
+		// v19- 形式: "Updated N package(s)."
+		{name: "v19/1件更新", output: "Updated 1 package.\n", expected: 1},
+		{name: "v19/2件更新", output: "Updated 2 packages.\n", expected: 2},
+		{name: "v19/大きい数字", output: "Updated 10 packages.\n", expected: 10},
+		{name: "v19/CRLF改行", output: "Updated 2 packages.\r\n", expected: 2},
+		{name: "v19/テーブル付き出力", output: "  ripgrep  14.0.0  14.1.0  Yes\n  bat      0.24.0  0.24.0  No\nUpdated 1 package.\n", expected: 1},
+		// v20+ 形式: "Overall updated N package(s)."
+		{name: "v20/更新なし", output: "No packages need updating.\nOverall updated 0 packages.\n", expected: 0},
+		{name: "v20/1件更新", output: "Overall updated 1 package.\n", expected: 1},
+		{name: "v20/2件更新", output: "Overall updated 2 packages.\n", expected: 2},
+		{name: "v20/大きい数字", output: "Overall updated 10 packages.\n", expected: 10},
+		{name: "v20/CRLF改行", output: "Overall updated 2 packages.\r\n", expected: 2},
+		{name: "v20/テーブル付き出力", output: "Package       Installed  Latest   Needs update\ncargo-update  v20.0.0    v20.0.1  Yes\n\nOverall updated 1 package.\n", expected: 1},
 	}
 
 	for _, tt := range tests {
@@ -349,7 +358,7 @@ exit /b 0
 			return
 		}
 
-		updateContent := "@echo off\r\nset mode=%DSX_TEST_CARGO_MODE%\r\nif \"%1\"==\"-a\" goto doupdate\r\necho invalid args 1>&2\r\nexit /b 1\r\n:doupdate\r\nif \"%mode%\"==\"update_error\" (\r\n  echo cargo install-update failed 1>&2\r\n  exit /b 1\r\n)\r\nif \"%mode%\"==\"updates\" (\r\n  echo Updated 2 packages.\r\n)\r\nexit /b 0\r\n"
+		updateContent := "@echo off\r\nset mode=%DSX_TEST_CARGO_MODE%\r\nif \"%1\"==\"install-update\" goto doinstallupdate\r\necho invalid args 1>&2\r\nexit /b 1\r\n:doinstallupdate\r\nif \"%2\"==\"-a\" goto doupdate\r\necho invalid args 1>&2\r\nexit /b 1\r\n:doupdate\r\nif \"%mode%\"==\"update_error\" (\r\n  echo cargo install-update failed 1>&2\r\n  exit /b 1\r\n)\r\nif \"%mode%\"==\"updates\" (\r\n  echo Overall updated 2 packages.\r\n)\r\nexit /b 0\r\n"
 
 		updatePath := filepath.Join(dir, "cargo-install-update.cmd")
 		if err := os.WriteFile(updatePath, []byte(updateContent), 0o755); err != nil {
@@ -426,7 +435,7 @@ esac
 			return
 		}
 
-		updateContent := "#!/bin/sh\nmode=\"${DSX_TEST_CARGO_MODE}\"\ncase \"$1\" in\n  -a)\n    if [ \"${mode}\" = \"update_error\" ]; then\n      echo \"cargo install-update failed\" 1>&2\n      exit 1\n    fi\n    if [ \"${mode}\" = \"updates\" ]; then\n      echo \"Updated 2 packages.\"\n    fi\n    exit 0\n    ;;\n  *)\n    echo \"invalid args\" 1>&2\n    exit 1\n    ;;\nesac\n"
+		updateContent := "#!/bin/sh\nmode=\"${DSX_TEST_CARGO_MODE}\"\ncase \"$1\" in\n  install-update)\n    case \"$2\" in\n      -a)\n        if [ \"${mode}\" = \"update_error\" ]; then\n          echo \"cargo install-update failed\" 1>&2\n          exit 1\n        fi\n        if [ \"${mode}\" = \"updates\" ]; then\n          echo \"Overall updated 2 packages.\"\n        fi\n        exit 0\n        ;;\n      *)\n        echo \"invalid args\" 1>&2\n        exit 1\n        ;;\n    esac\n    ;;\n  *)\n    echo \"invalid args\" 1>&2\n    exit 1\n    ;;\nesac\n"
 
 		updatePath := filepath.Join(dir, "cargo-install-update")
 		if err := os.WriteFile(updatePath, []byte(updateContent), 0o755); err != nil {
@@ -449,14 +458,14 @@ func writeFakeCIUBinary(t *testing.T, dir string) {
 	}
 
 	if runtime.GOOS == "windows" {
-		content := "@echo off\r\nset mode=%DSX_TEST_CARGO_MODE%\r\nif \"%1\"==\"-a\" goto doupdate\r\nexit /b 1\r\n:doupdate\r\nif \"%mode%\"==\"updates\" (\r\n  echo Updated 2 packages.\r\n)\r\nexit /b 0\r\n"
+		content := "@echo off\r\nset mode=%DSX_TEST_CARGO_MODE%\r\nif \"%1\"==\"install-update\" goto doinstallupdate\r\nexit /b 1\r\n:doinstallupdate\r\nif \"%2\"==\"-a\" goto doupdate\r\nexit /b 1\r\n:doupdate\r\nif \"%mode%\"==\"updates\" (\r\n  echo Overall updated 2 packages.\r\n)\r\nexit /b 0\r\n"
 		path := filepath.Join(dir, "cargo-install-update.cmd")
 
 		if err := os.WriteFile(path, []byte(content), 0o755); err != nil {
 			t.Fatalf("fake cargo-install-update.cmd write failed: %v", err)
 		}
 	} else {
-		content := "#!/bin/sh\nmode=\"${DSX_TEST_CARGO_MODE}\"\ncase \"$1\" in\n  -a)\n    if [ \"${mode}\" = \"updates\" ]; then\n      echo \"Updated 2 packages.\"\n    fi\n    exit 0\n    ;;\n  *)\n    exit 1\n    ;;\nesac\n"
+		content := "#!/bin/sh\nmode=\"${DSX_TEST_CARGO_MODE}\"\ncase \"$1\" in\n  install-update)\n    case \"$2\" in\n      -a)\n        if [ \"${mode}\" = \"updates\" ]; then\n          echo \"Overall updated 2 packages.\"\n        fi\n        exit 0\n        ;;\n      *)\n        exit 1\n        ;;\n    esac\n    ;;\n  *)\n    exit 1\n    ;;\nesac\n"
 		path := filepath.Join(dir, "cargo-install-update")
 
 		if err := os.WriteFile(path, []byte(content), 0o755); err != nil {

--- a/internal/updater/cargo_test.go
+++ b/internal/updater/cargo_test.go
@@ -275,10 +275,12 @@ func TestCargoUpdater_Update(t *testing.T) {
 				// また CARGO_HOME を設定して cargoInstallUpdateBinPath のフォールバックが機能するよう
 				// CARGO_HOME/bin にダミーバイナリを配置する（cargo install 後の状態をシミュレート）。
 				writeFakeCargoCommandImpl(t, fakeDir, false)
+
 				cargoHomeDir := filepath.Join(fakeDir, "cargo_home")
 				if !tc.noCargoBin {
 					writeFakeCIUBinary(t, filepath.Join(cargoHomeDir, "bin"))
 				}
+
 				t.Setenv("CARGO_HOME", cargoHomeDir)
 				t.Setenv("PATH", fakeDir)
 			default:
@@ -561,7 +563,7 @@ func TestCargoUpdateArgs(t *testing.T) {
 
 // writeFakeVersionBinary は --version に対して versionOut を返す fake バイナリを作成し、そのパスを返します。
 // versionOut が空の場合は --version で exit 1 を返します。
-func writeFakeVersionBinary(t *testing.T, dir string, versionOut string) string {
+func writeFakeVersionBinary(t *testing.T, dir, versionOut string) string {
 	t.Helper()
 
 	if runtime.GOOS == "windows" {

--- a/internal/updater/cargo_test.go
+++ b/internal/updater/cargo_test.go
@@ -145,7 +145,6 @@ func TestCargoUpdater_Check(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			fakeDir := t.TempDir()
 			writeFakeCargoCommand(t, fakeDir)
@@ -179,6 +178,7 @@ func TestCargoUpdater_Update(t *testing.T) {
 		mode        string
 		noUpdate    bool // true: cargo-install-update バイナリを PATH に含めない
 		noCargoBin  bool // true: CARGO_HOME/bin にもバイナリを配置しない（フォールバック失敗のテスト用）
+		v19         bool // true: v19 スタイルの cargo-install-update を使用（バージョン互換テスト用）
 		opts        UpdateOptions
 		wantErr     bool
 		errContains string
@@ -240,27 +240,49 @@ func TestCargoUpdater_Update(t *testing.T) {
 			wantErr:     true,
 			errContains: "PATH に見つかりません",
 		},
+		{
+			name:        "v19環境での更新成功",
+			mode:        "updates",
+			v19:         true,
+			opts:        UpdateOptions{},
+			wantErr:     false,
+			msgContains: "件のパッケージを更新しました",
+			wantUpdated: 2,
+		},
+		{
+			name:        "v19環境での更新なし",
+			mode:        "none",
+			v19:         true,
+			opts:        UpdateOptions{},
+			wantErr:     false,
+			msgContains: "更新なし",
+		},
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			fakeDir := t.TempDir()
-			writeFakeCargoCommandImpl(t, fakeDir, !tc.noUpdate)
 
-			// noUpdate=true の場合は PATH を fakeDir のみに絞り、
-			// 実環境の cargo-install-update が LookPath に引っかからないようにする。
-			// また CARGO_HOME を設定して cargoInstallUpdateBinPath のフォールバックが機能するよう
-			// CARGO_HOME/bin にダミーバイナリを配置する（cargo install 後の状態をシミュレート）。
-			if tc.noUpdate {
+			switch {
+			case tc.v19:
+				// v19: cargo のみ書き、cargo-install-update は v19 スタイルで別途作成
+				writeFakeCargoCommandImpl(t, fakeDir, false)
+				writeFakeCargoInstallUpdateV19Binary(t, fakeDir)
+				t.Setenv("PATH", fakeDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+			case tc.noUpdate:
+				// noUpdate=true の場合は PATH を fakeDir のみに絞り、
+				// 実環境の cargo-install-update が LookPath に引っかからないようにする。
+				// また CARGO_HOME を設定して cargoInstallUpdateBinPath のフォールバックが機能するよう
+				// CARGO_HOME/bin にダミーバイナリを配置する（cargo install 後の状態をシミュレート）。
+				writeFakeCargoCommandImpl(t, fakeDir, false)
 				cargoHomeDir := filepath.Join(fakeDir, "cargo_home")
 				if !tc.noCargoBin {
 					writeFakeCIUBinary(t, filepath.Join(cargoHomeDir, "bin"))
 				}
-
 				t.Setenv("CARGO_HOME", cargoHomeDir)
 				t.Setenv("PATH", fakeDir)
-			} else {
+			default:
+				writeFakeCargoCommandImpl(t, fakeDir, true)
 				t.Setenv("PATH", fakeDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 			}
 
@@ -476,4 +498,103 @@ func writeFakeCIUBinary(t *testing.T, dir string) {
 			t.Fatalf("fake cargo-install-update chmod failed: %v", err)
 		}
 	}
+}
+
+// writeFakeCargoInstallUpdateV19Binary は v19 スタイルの fake cargo-install-update を作成します。
+// --version は "cargo-install-update 16.0.0" を返し、-a を直接受け付けます。
+func writeFakeCargoInstallUpdateV19Binary(t *testing.T, dir string) {
+	t.Helper()
+
+	if runtime.GOOS == "windows" {
+		content := "@echo off\r\nset mode=%DSX_TEST_CARGO_MODE%\r\nif \"%1\"==\"--version\" (\r\n  echo cargo-install-update 16.0.0\r\n  exit /b 0\r\n)\r\nif \"%1\"==\"-a\" goto doupdate\r\necho invalid args 1>&2\r\nexit /b 1\r\n:doupdate\r\nif \"%mode%\"==\"update_error\" (\r\n  echo cargo install-update failed 1>&2\r\n  exit /b 1\r\n)\r\nif \"%mode%\"==\"updates\" (\r\n  echo Updated 2 packages.\r\n)\r\nexit /b 0\r\n"
+		path := filepath.Join(dir, "cargo-install-update.cmd")
+
+		if err := os.WriteFile(path, []byte(content), 0o755); err != nil {
+			t.Fatalf("writeFakeCargoInstallUpdateV19Binary write failed: %v", err)
+		}
+	} else {
+		content := "#!/bin/sh\nmode=\"${DSX_TEST_CARGO_MODE}\"\ncase \"$1\" in\n  --version)\n    echo \"cargo-install-update 16.0.0\"\n    exit 0\n    ;;\n  -a)\n    if [ \"${mode}\" = \"update_error\" ]; then\n      echo \"cargo install-update failed\" 1>&2\n      exit 1\n    fi\n    if [ \"${mode}\" = \"updates\" ]; then\n      echo \"Updated 2 packages.\"\n    fi\n    exit 0\n    ;;\n  *)\n    echo \"invalid args\" 1>&2\n    exit 1\n    ;;\nesac\n"
+		path := filepath.Join(dir, "cargo-install-update")
+
+		if err := os.WriteFile(path, []byte(content), 0o755); err != nil {
+			t.Fatalf("writeFakeCargoInstallUpdateV19Binary write failed: %v", err)
+		}
+
+		if err := os.Chmod(path, 0o755); err != nil {
+			t.Fatalf("writeFakeCargoInstallUpdateV19Binary chmod failed: %v", err)
+		}
+	}
+}
+
+func TestCargoUpdateArgs(t *testing.T) {
+	tests := []struct {
+		name       string
+		versionOut string // --version の出力（空なら exit 1）
+		wantArgs   []string
+	}{
+		{
+			name:       "v20+（cargo N.N.N 形式）",
+			versionOut: "cargo 20.0.0",
+			wantArgs:   []string{"install-update", "-a"},
+		},
+		{
+			name:       "v19-（cargo-install-update N.N.N 形式）",
+			versionOut: "cargo-install-update 16.0.0",
+			wantArgs:   []string{"-a"},
+		},
+		{
+			name:       "--version 失敗時は v20+ 形式にフォールバック",
+			versionOut: "", // exit 1
+			wantArgs:   []string{"install-update", "-a"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			binPath := writeFakeVersionBinary(t, dir, tt.versionOut)
+			got := cargoUpdateArgs(binPath)
+			assert.Equal(t, tt.wantArgs, got)
+		})
+	}
+}
+
+// writeFakeVersionBinary は --version に対して versionOut を返す fake バイナリを作成し、そのパスを返します。
+// versionOut が空の場合は --version で exit 1 を返します。
+func writeFakeVersionBinary(t *testing.T, dir string, versionOut string) string {
+	t.Helper()
+
+	if runtime.GOOS == "windows" {
+		var content string
+		if versionOut == "" {
+			content = "@echo off\r\nexit /b 1\r\n"
+		} else {
+			content = "@echo off\r\nif \"%1\"==\"--version\" (\r\n  echo " + versionOut + "\r\n  exit /b 0\r\n)\r\nexit /b 1\r\n"
+		}
+
+		path := filepath.Join(dir, "fake-bin.cmd")
+		if err := os.WriteFile(path, []byte(content), 0o755); err != nil {
+			t.Fatalf("writeFakeVersionBinary write failed: %v", err)
+		}
+
+		return path
+	}
+
+	var content string
+	if versionOut == "" {
+		content = "#!/bin/sh\nexit 1\n"
+	} else {
+		content = "#!/bin/sh\ncase \"$1\" in\n  --version)\n    echo \"" + versionOut + "\"\n    exit 0\n    ;;\nesac\nexit 1\n"
+	}
+
+	path := filepath.Join(dir, "fake-bin")
+	if err := os.WriteFile(path, []byte(content), 0o755); err != nil {
+		t.Fatalf("writeFakeVersionBinary write failed: %v", err)
+	}
+
+	if err := os.Chmod(path, 0o755); err != nil {
+		t.Fatalf("writeFakeVersionBinary chmod failed: %v", err)
+	}
+
+	return path
 }


### PR DESCRIPTION
## 概要

実機テストで発覚した `cargo-update v20` の API 変更に対応します。

### 問題

`cargo-update v20` でバイナリのインターフェースが変更され、`cargo-install-update -a`（旧形式）が無効になった。

```
error: Found argument '-a' which wasn't expected, or isn't valid in this context
USAGE:
    cargo <SUBCOMMAND>
```

出力サマリ形式も変更:
- v19-: `Updated N packages.`
- v20+: `Overall updated N packages.`

### 変更内容

- `cargo.go`: 呼び出しを `cargo-install-update install-update -a`（v20 サブコマンド形式）に変更
- `cargo.go`: `parseUpdateCount` に `Overall updated N` パターンを追加（v19 との後方互換維持）
- `cargo_test.go`: フェイクバイナリを v20 形式に更新
- `cargo_test.go`: `parseUpdateCount` テストケースに v19/v20 両形式を追加
- `CHANGELOG.md`: 変更内容を記録

## テスト計画

- [x] `go test ./internal/updater/ -run TestCargoUpdater` 全件 PASS
- [x] `go test ./...` 全件 PASS
- [x] pre-push lint/test PASS
- [x] `dsx sys update --dry-run --no-tui` で cargo 2件検出を確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)