### PR TITLE
feat: sys updateにマネージャ本体更新フェーズを追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@
 
 ## [Unreleased]
 
+### Added
+
+- `dsx sys update` にマネージャ本体更新フェーズを追加。対応マネージャは通常更新フェーズの前に `CheckSelfUpdate` / `SelfUpdate` を実行し、dry-run では副作用なしで予定を表示するようになった（#81）
+- `uv` updater で `uv self update --dry-run` / `uv self update` による uv 本体更新に対応。`uv tool upgrade --all` は従来通り通常更新フェーズで実行し、self update 非対応のインストール経路では本体更新をスキップする（#81）
+
+### Changed
+
+- `pnpm` のグローバル更新を `pnpm update -g` から `pnpm update -g --latest` に変更し、version range に制限されず latest まで更新するようにした（#81）
+
 ## [v0.6.4] - 2026-05-28
 
 ### Performance

--- a/README.md
+++ b/README.md
@@ -187,6 +187,12 @@ dsx sys discover --manager go # Go バイナリのみスキャン
 `snapd unavailable` の環境では `snap` を利用不可として自動スキップします。
 `sys.enable` に未インストールのマネージャが含まれている場合は、警告を表示してスキップし、利用可能なマネージャのみ継続実行します。
 
+`sys update` は対応マネージャについて「マネージャ本体更新フェーズ」→「通常更新フェーズ」の順に実行します。
+たとえば `uv` は `uv self update` で uv 本体を確認・更新してから、通常更新フェーズで `uv tool upgrade --all` を実行します。
+`uv self update` が利用できないインストール経路では、uv 本体更新はスキップし、通常更新フェーズを継続します。
+`dsx` 本体はこのフェーズでは更新せず、従来通り `dsx self-update` で扱います。
+`pnpm` のグローバル更新は `pnpm update -g --latest` を使用し、version range に制限されず latest まで更新します。
+
 Go updater は `go.targets` のうち `@latest` 対象について、インストール済みバイナリの module 情報と `go list -m -json <module>@latest` を best-effort で比較します。
 すでに最新版の Go ツールは `go install` をスキップし、判定不能なツールや固定バージョン target は従来通り安全側で `go install` を実行します。
 `go.targets` に `github.com/scottlz0310/dsx/cmd/dsx` が含まれる場合、Go updater では dsx 本体を更新しません。

--- a/cmd/dsx/sys.go
+++ b/cmd/dsx/sys.go
@@ -131,9 +131,8 @@ func runSysUpdate(cmd *cobra.Command, args []string) error {
 	}
 
 	jobs := resolveSysJobs(cfg.Control.Concurrency, sysJobs)
-	exclusiveUpdaters, parallelUpdaters := splitUpdatersForExecution(enabledUpdaters)
 
-	stats, err := runSysUpdatePhases(ctx, cfg, opts, exclusiveUpdaters, parallelUpdaters, jobs, useTUI)
+	stats, err := runSysUpdatePhases(ctx, cfg, opts, enabledUpdaters, jobs, useTUI)
 	if err != nil {
 		return err
 	}
@@ -158,9 +157,14 @@ func runSysUpdate(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-// runSysUpdatePhases は単独実行・並列実行の各フェーズを実行します。
-func runSysUpdatePhases(ctx context.Context, cfg *config.Config, opts updater.UpdateOptions, exclusiveUpdaters, parallelUpdaters []updater.Updater, jobs int, useTUI bool) (updateStats, error) {
+// runSysUpdatePhases はマネージャ本体更新・単独実行・並列実行の各フェーズを実行します。
+func runSysUpdatePhases(ctx context.Context, cfg *config.Config, opts updater.UpdateOptions, enabledUpdaters []updater.Updater, jobs int, useTUI bool) (updateStats, error) {
 	var stats updateStats
+
+	remainingUpdaters, selfUpdateStats := runManagerSelfUpdatePhase(ctx, opts, enabledUpdaters, useTUI)
+	mergeUpdateStats(&stats, selfUpdateStats)
+
+	exclusiveUpdaters, parallelUpdaters := splitUpdatersForExecution(remainingUpdaters)
 
 	if len(exclusiveUpdaters) > 0 {
 		if err := runExclusivePhase(ctx, cfg, opts, exclusiveUpdaters, useTUI, &stats); err != nil {
@@ -175,6 +179,203 @@ func runSysUpdatePhases(ctx context.Context, cfg *config.Config, opts updater.Up
 	}
 
 	return stats, nil
+}
+
+type managerSelfUpdateTarget struct {
+	updater updater.Updater
+	self    updater.ManagerSelfUpdater
+}
+
+func runManagerSelfUpdatePhase(ctx context.Context, opts updater.UpdateOptions, updaters []updater.Updater, useTUI bool) ([]updater.Updater, updateStats) {
+	targets := collectManagerSelfUpdateTargets(updaters)
+	if len(targets) == 0 {
+		return updaters, updateStats{}
+	}
+
+	if useTUI {
+		return runManagerSelfUpdatePhaseWithTUI(ctx, opts, updaters, targets)
+	}
+
+	printManagerSelfUpdatePhaseHeader()
+
+	var stats updateStats
+
+	skipNormalUpdate := make(map[string]bool)
+
+	for _, target := range targets {
+		select {
+		case <-ctx.Done():
+			stats.Errors = append(stats.Errors, fmt.Errorf("マネージャ本体更新フェーズがタイムアウトまたはキャンセルされました"))
+
+			return filterNormalUpdateUpdaters(updaters, skipNormalUpdate), stats
+		default:
+		}
+
+		printManagerSelfUpdateHeader(target.updater)
+
+		result, err := executeManagerSelfUpdate(ctx, target.self, opts)
+		if err != nil {
+			recordManagerSelfUpdateError(target.updater, err, &stats)
+			fmt.Fprintf(os.Stderr, "❌ エラー: %v\n", err)
+			fmt.Println()
+
+			continue
+		}
+
+		printUpdaterResult(&result.UpdateResult)
+		fmt.Println()
+
+		mergeSelfUpdateResult(&stats, result)
+
+		if !result.ShouldContinueNormalUpdate() {
+			skipNormalUpdate[target.updater.Name()] = true
+		}
+	}
+
+	return filterNormalUpdateUpdaters(updaters, skipNormalUpdate), stats
+}
+
+func runManagerSelfUpdatePhaseWithTUI(ctx context.Context, opts updater.UpdateOptions, updaters []updater.Updater, targets []managerSelfUpdateTarget) ([]updater.Updater, updateStats) {
+	var (
+		stats            updateStats
+		statsMu          sync.Mutex
+		skipNormalUpdate = make(map[string]bool)
+	)
+
+	jobs := make([]runner.Job, 0, len(targets))
+	for _, item := range targets {
+		target := item
+
+		jobs = append(jobs, runner.Job{
+			Name: target.updater.Name() + "-self-update",
+			Run: func(jobCtx context.Context) error {
+				result, err := executeManagerSelfUpdate(jobCtx, target.self, opts)
+				if err != nil {
+					if isContextCancellation(err) {
+						return err
+					}
+
+					statsMu.Lock()
+					recordManagerSelfUpdateError(target.updater, err, &stats)
+					statsMu.Unlock()
+
+					return err
+				}
+
+				statsMu.Lock()
+				mergeSelfUpdateResult(&stats, result)
+
+				if !result.ShouldContinueNormalUpdate() {
+					skipNormalUpdate[target.updater.Name()] = true
+				}
+				statsMu.Unlock()
+
+				return nil
+			},
+		})
+	}
+
+	summary := runJobsWithOptionalTUI(ctx, "マネージャ本体更新 進捗", 1, jobs, true, sysLogFile)
+	if summary.Skipped > 0 {
+		stats.Errors = append(stats.Errors, fmt.Errorf("キャンセルまたはタイムアウトによりマネージャ本体更新 %d 件をスキップしました", summary.Skipped))
+	}
+
+	return filterNormalUpdateUpdaters(updaters, skipNormalUpdate), stats
+}
+
+func collectManagerSelfUpdateTargets(updaters []updater.Updater) []managerSelfUpdateTarget {
+	targets := make([]managerSelfUpdateTarget, 0, len(updaters))
+
+	for _, u := range updaters {
+		self, ok := u.(updater.ManagerSelfUpdater)
+		if !ok {
+			continue
+		}
+
+		targets = append(targets, managerSelfUpdateTarget{updater: u, self: self})
+	}
+
+	return targets
+}
+
+func executeManagerSelfUpdate(ctx context.Context, self updater.ManagerSelfUpdater, opts updater.UpdateOptions) (*updater.SelfUpdateResult, error) {
+	if !opts.DryRun {
+		result, err := self.SelfUpdate(ctx, opts)
+		if result == nil {
+			result = &updater.SelfUpdateResult{Continuation: updater.ContinueNormalUpdate}
+		}
+
+		return result, err
+	}
+
+	checkResult, err := self.CheckSelfUpdate(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return buildDryRunSelfUpdateResult(checkResult), nil
+}
+
+func buildDryRunSelfUpdateResult(checkResult *updater.CheckResult) *updater.SelfUpdateResult {
+	result := &updater.SelfUpdateResult{
+		Continuation: updater.ContinueNormalUpdate,
+	}
+
+	if checkResult == nil {
+		result.Message = "マネージャ本体更新を確認しました（DryRunモード）"
+
+		return result
+	}
+
+	result.Packages = checkResult.Packages
+	if checkResult.AvailableUpdates > 0 {
+		result.Message = fmt.Sprintf("%d 件のマネージャ本体更新が可能です（DryRunモード）", checkResult.AvailableUpdates)
+		if checkResult.Message != "" {
+			result.Message = checkResult.Message + "（DryRunモード）"
+		}
+
+		return result
+	}
+
+	if checkResult.Message != "" {
+		result.Message = checkResult.Message + "（DryRunモード）"
+	} else {
+		result.Message = "マネージャ本体は最新です（DryRunモード）"
+	}
+
+	return result
+}
+
+func mergeSelfUpdateResult(stats *updateStats, result *updater.SelfUpdateResult) {
+	if result == nil {
+		return
+	}
+
+	stats.Updated += result.UpdatedCount
+	stats.Failed += result.FailedCount
+	stats.Errors = append(stats.Errors, result.Errors...)
+}
+
+func recordManagerSelfUpdateError(u updater.Updater, err error, stats *updateStats) {
+	stats.Errors = append(stats.Errors, fmt.Errorf("%s 本体更新: %w", u.Name(), err))
+	stats.Failed++
+}
+
+func filterNormalUpdateUpdaters(updaters []updater.Updater, skip map[string]bool) []updater.Updater {
+	if len(skip) == 0 {
+		return updaters
+	}
+
+	filtered := make([]updater.Updater, 0, len(updaters))
+	for _, u := range updaters {
+		if skip[u.Name()] {
+			continue
+		}
+
+		filtered = append(filtered, u)
+	}
+
+	return filtered
 }
 
 func runExclusivePhase(ctx context.Context, cfg *config.Config, opts updater.UpdateOptions, updaters []updater.Updater, useTUI bool, stats *updateStats) error {
@@ -225,6 +426,17 @@ func printSysUpdateDryRunNotice(dryRun bool) {
 
 	fmt.Println("📋 DryRun モード: 実際の更新は行いません")
 	fmt.Println()
+}
+
+func printManagerSelfUpdatePhaseHeader() {
+	fmt.Println("🧰 マネージャ本体更新フェーズを開始します...")
+	fmt.Println()
+}
+
+func printManagerSelfUpdateHeader(u updater.Updater) {
+	fmt.Printf("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n")
+	fmt.Printf("🧰 %s 本体更新 (%s)\n", u.DisplayName(), u.Name())
+	fmt.Printf("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n")
 }
 
 // updateStats は更新処理の統計情報を保持します。

--- a/cmd/dsx/sys.go
+++ b/cmd/dsx/sys.go
@@ -186,6 +186,8 @@ type managerSelfUpdateTarget struct {
 	self    updater.ManagerSelfUpdater
 }
 
+var runManagerSelfUpdateJobs = runJobsWithOptionalTUI
+
 func runManagerSelfUpdatePhase(ctx context.Context, opts updater.UpdateOptions, updaters []updater.Updater, useTUI bool) ([]updater.Updater, updateStats) {
 	targets := collectManagerSelfUpdateTargets(updaters)
 	if len(targets) == 0 {
@@ -275,7 +277,7 @@ func runManagerSelfUpdatePhaseWithTUI(ctx context.Context, opts updater.UpdateOp
 		})
 	}
 
-	summary := runJobsWithOptionalTUI(ctx, "マネージャ本体更新 進捗", 1, jobs, true, sysLogFile)
+	summary := runManagerSelfUpdateJobs(ctx, "マネージャ本体更新 進捗", 1, jobs, true, sysLogFile)
 	if summary.Skipped > 0 {
 		stats.Errors = append(stats.Errors, fmt.Errorf("キャンセルまたはタイムアウトによりマネージャ本体更新 %d 件をスキップしました", summary.Skipped))
 	}

--- a/cmd/dsx/sys_test.go
+++ b/cmd/dsx/sys_test.go
@@ -43,6 +43,44 @@ func (s stubUpdater) Configure(config.ManagerConfig) error {
 	return nil
 }
 
+type selfUpdateStubUpdater struct {
+	stubUpdater
+	checkResult *updater.CheckResult
+	checkErr    error
+	selfResult  *updater.SelfUpdateResult
+	selfErr     error
+	checkCalls  int
+	selfCalls   int
+}
+
+func (s *selfUpdateStubUpdater) CheckSelfUpdate(context.Context) (*updater.CheckResult, error) {
+	s.checkCalls++
+
+	if s.checkErr != nil {
+		return nil, s.checkErr
+	}
+
+	if s.checkResult != nil {
+		return s.checkResult, nil
+	}
+
+	return &updater.CheckResult{}, nil
+}
+
+func (s *selfUpdateStubUpdater) SelfUpdate(context.Context, updater.UpdateOptions) (*updater.SelfUpdateResult, error) {
+	s.selfCalls++
+
+	if s.selfErr != nil {
+		return s.selfResult, s.selfErr
+	}
+
+	if s.selfResult != nil {
+		return s.selfResult, nil
+	}
+
+	return &updater.SelfUpdateResult{Continuation: updater.ContinueNormalUpdate}, nil
+}
+
 func TestResolveSysJobs(t *testing.T) {
 	t.Parallel()
 
@@ -88,6 +126,74 @@ func TestResolveSysJobs(t *testing.T) {
 				t.Fatalf("resolveSysJobs(%d, %d) = %d, want %d", tc.configJobs, tc.flagJobs, got, tc.want)
 			}
 		})
+	}
+}
+
+func TestExecuteManagerSelfUpdate_DryRunUsesCheckOnly(t *testing.T) {
+	u := &selfUpdateStubUpdater{
+		stubUpdater: stubUpdater{name: "uv"},
+		checkResult: &updater.CheckResult{
+			AvailableUpdates: 1,
+			Packages: []updater.PackageInfo{
+				{Name: "uv", CurrentVersion: "0.11.16", NewVersion: "0.11.17"},
+			},
+			Message: "uv 本体の更新が可能です",
+		},
+	}
+
+	got, err := executeManagerSelfUpdate(context.Background(), u, updater.UpdateOptions{DryRun: true})
+	if err != nil {
+		t.Fatalf("executeManagerSelfUpdate returned error: %v", err)
+	}
+
+	if u.checkCalls != 1 {
+		t.Fatalf("CheckSelfUpdate calls = %d, want 1", u.checkCalls)
+	}
+
+	if u.selfCalls != 0 {
+		t.Fatalf("SelfUpdate calls = %d, want 0", u.selfCalls)
+	}
+
+	if got.UpdatedCount != 0 {
+		t.Fatalf("UpdatedCount = %d, want 0", got.UpdatedCount)
+	}
+
+	if !strings.Contains(got.Message, "DryRun") {
+		t.Fatalf("Message = %q, want DryRun", got.Message)
+	}
+}
+
+func TestRunManagerSelfUpdatePhase_SkipNormalUpdate(t *testing.T) {
+	selfUpdater := &selfUpdateStubUpdater{
+		stubUpdater: stubUpdater{name: "uv"},
+		selfResult: &updater.SelfUpdateResult{
+			UpdateResult: updater.UpdateResult{
+				UpdatedCount: 1,
+				Message:      "uv 本体を更新しました",
+			},
+			Continuation: updater.SkipNormalUpdate,
+		},
+	}
+	normalUpdater := stubUpdater{name: "npm"}
+
+	remaining, stats := runManagerSelfUpdatePhase(
+		context.Background(),
+		updater.UpdateOptions{},
+		[]updater.Updater{selfUpdater, normalUpdater},
+		false,
+	)
+
+	if stats.Updated != 1 {
+		t.Fatalf("Updated = %d, want 1", stats.Updated)
+	}
+
+	if len(remaining) != 1 || remaining[0].Name() != "npm" {
+		names := make([]string, 0, len(remaining))
+		for _, u := range remaining {
+			names = append(names, u.Name())
+		}
+
+		t.Fatalf("remaining = %v, want [npm]", names)
 	}
 }
 

--- a/cmd/dsx/sys_test.go
+++ b/cmd/dsx/sys_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/scottlz0310/dsx/internal/config"
+	"github.com/scottlz0310/dsx/internal/runner"
 	"github.com/scottlz0310/dsx/internal/updater"
 )
 
@@ -51,6 +52,7 @@ type selfUpdateStubUpdater struct {
 	selfErr     error
 	checkCalls  int
 	selfCalls   int
+	nilSelf     bool
 }
 
 func (s *selfUpdateStubUpdater) CheckSelfUpdate(context.Context) (*updater.CheckResult, error) {
@@ -72,6 +74,10 @@ func (s *selfUpdateStubUpdater) SelfUpdate(context.Context, updater.UpdateOption
 
 	if s.selfErr != nil {
 		return s.selfResult, s.selfErr
+	}
+
+	if s.nilSelf {
+		return nil, nil
 	}
 
 	if s.selfResult != nil {
@@ -163,6 +169,20 @@ func TestExecuteManagerSelfUpdate_DryRunUsesCheckOnly(t *testing.T) {
 	}
 }
 
+func TestRunManagerSelfUpdatePhase_NoTargets(t *testing.T) {
+	input := []updater.Updater{stubUpdater{name: "npm"}}
+
+	remaining, stats := runManagerSelfUpdatePhase(context.Background(), updater.UpdateOptions{}, input, false)
+
+	if len(stats.Errors) != 0 || stats.Updated != 0 || stats.Failed != 0 {
+		t.Fatalf("stats = %+v, want empty", stats)
+	}
+
+	if len(remaining) != 1 || remaining[0].Name() != "npm" {
+		t.Fatalf("remaining = %v, want original updater", updaterNames(remaining))
+	}
+}
+
 func TestRunManagerSelfUpdatePhase_SkipNormalUpdate(t *testing.T) {
 	selfUpdater := &selfUpdateStubUpdater{
 		stubUpdater: stubUpdater{name: "uv"},
@@ -195,6 +215,329 @@ func TestRunManagerSelfUpdatePhase_SkipNormalUpdate(t *testing.T) {
 
 		t.Fatalf("remaining = %v, want [npm]", names)
 	}
+}
+
+func TestRunManagerSelfUpdatePhase_ContextCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	selfUpdater := &selfUpdateStubUpdater{
+		stubUpdater: stubUpdater{name: "uv"},
+	}
+
+	remaining, stats := runManagerSelfUpdatePhase(
+		ctx,
+		updater.UpdateOptions{},
+		[]updater.Updater{selfUpdater},
+		false,
+	)
+
+	if selfUpdater.selfCalls != 0 {
+		t.Fatalf("SelfUpdate calls = %d, want 0", selfUpdater.selfCalls)
+	}
+
+	if len(stats.Errors) != 1 || !strings.Contains(stats.Errors[0].Error(), "キャンセル") {
+		t.Fatalf("errors = %v, want cancellation error", stats.Errors)
+	}
+
+	if len(remaining) != 1 || remaining[0].Name() != "uv" {
+		t.Fatalf("remaining = %v, want [uv]", updaterNames(remaining))
+	}
+}
+
+func TestRunManagerSelfUpdatePhase_RecordsSelfUpdateError(t *testing.T) {
+	selfUpdater := &selfUpdateStubUpdater{
+		stubUpdater: stubUpdater{name: "uv"},
+		selfErr:     errors.New("self update failed"),
+	}
+
+	remaining, stats := runManagerSelfUpdatePhase(
+		context.Background(),
+		updater.UpdateOptions{},
+		[]updater.Updater{selfUpdater},
+		false,
+	)
+
+	if stats.Failed != 1 {
+		t.Fatalf("Failed = %d, want 1", stats.Failed)
+	}
+
+	if len(stats.Errors) != 1 || !strings.Contains(stats.Errors[0].Error(), "uv 本体更新") {
+		t.Fatalf("errors = %v, want uv self update error", stats.Errors)
+	}
+
+	if len(remaining) != 1 || remaining[0].Name() != "uv" {
+		t.Fatalf("remaining = %v, want [uv]", updaterNames(remaining))
+	}
+}
+
+func TestRunManagerSelfUpdatePhaseWithTUI_CollectsJobResults(t *testing.T) {
+	previous := runManagerSelfUpdateJobs
+	t.Cleanup(func() {
+		runManagerSelfUpdateJobs = previous
+	})
+
+	var jobNames []string
+
+	runManagerSelfUpdateJobs = func(ctx context.Context, title string, maxJobs int, jobs []runner.Job, useTUI bool, logFile string) runner.Summary {
+		if title != "マネージャ本体更新 進捗" {
+			t.Fatalf("title = %q, want マネージャ本体更新 進捗", title)
+		}
+
+		if maxJobs != 1 {
+			t.Fatalf("maxJobs = %d, want 1", maxJobs)
+		}
+
+		if !useTUI {
+			t.Fatalf("useTUI = false, want true")
+		}
+
+		summary := runner.Summary{
+			Total:   len(jobs),
+			Results: make([]runner.Result, len(jobs)),
+		}
+
+		for i, job := range jobs {
+			jobNames = append(jobNames, job.Name)
+
+			err := job.Run(ctx)
+			if err != nil {
+				summary.Results[i] = runner.Result{Name: job.Name, Status: runner.StatusFailed, Err: err}
+				summary.Failed++
+
+				continue
+			}
+
+			summary.Results[i] = runner.Result{Name: job.Name, Status: runner.StatusSuccess}
+			summary.Success++
+		}
+
+		return summary
+	}
+
+	skipUpdater := &selfUpdateStubUpdater{
+		stubUpdater: stubUpdater{name: "uv"},
+		selfResult: &updater.SelfUpdateResult{
+			UpdateResult: updater.UpdateResult{UpdatedCount: 1},
+			Continuation: updater.SkipNormalUpdate,
+		},
+	}
+	errorUpdater := &selfUpdateStubUpdater{
+		stubUpdater: stubUpdater{name: "pnpm"},
+		selfErr:     errors.New("pnpm self update failed"),
+	}
+	canceledUpdater := &selfUpdateStubUpdater{
+		stubUpdater: stubUpdater{name: "canceled"},
+		selfErr:     context.Canceled,
+	}
+	normalUpdater := stubUpdater{name: "npm"}
+
+	remaining, stats := runManagerSelfUpdatePhaseWithTUI(
+		context.Background(),
+		updater.UpdateOptions{},
+		[]updater.Updater{skipUpdater, errorUpdater, canceledUpdater, normalUpdater},
+		[]managerSelfUpdateTarget{
+			{updater: skipUpdater, self: skipUpdater},
+			{updater: errorUpdater, self: errorUpdater},
+			{updater: canceledUpdater, self: canceledUpdater},
+		},
+	)
+
+	if stats.Updated != 1 {
+		t.Fatalf("Updated = %d, want 1", stats.Updated)
+	}
+
+	if stats.Failed != 1 {
+		t.Fatalf("Failed = %d, want 1", stats.Failed)
+	}
+
+	if len(stats.Errors) != 1 || !strings.Contains(stats.Errors[0].Error(), "pnpm 本体更新") {
+		t.Fatalf("errors = %v, want pnpm self update error", stats.Errors)
+	}
+
+	wantNames := []string{"uv-self-update", "pnpm-self-update", "canceled-self-update"}
+	if strings.Join(jobNames, ",") != strings.Join(wantNames, ",") {
+		t.Fatalf("jobNames = %v, want %v", jobNames, wantNames)
+	}
+
+	if strings.Join(updaterNames(remaining), ",") != "pnpm,canceled,npm" {
+		t.Fatalf("remaining = %v, want [pnpm canceled npm]", updaterNames(remaining))
+	}
+}
+
+func TestRunManagerSelfUpdatePhaseWithTUI_RecordsSkippedSummary(t *testing.T) {
+	previous := runManagerSelfUpdateJobs
+	t.Cleanup(func() {
+		runManagerSelfUpdateJobs = previous
+	})
+
+	runManagerSelfUpdateJobs = func(context.Context, string, int, []runner.Job, bool, string) runner.Summary {
+		return runner.Summary{Skipped: 2}
+	}
+
+	_, stats := runManagerSelfUpdatePhaseWithTUI(
+		context.Background(),
+		updater.UpdateOptions{},
+		nil,
+		nil,
+	)
+
+	if len(stats.Errors) != 1 || !strings.Contains(stats.Errors[0].Error(), "2 件をスキップ") {
+		t.Fatalf("errors = %v, want skipped summary error", stats.Errors)
+	}
+}
+
+func TestBuildDryRunSelfUpdateResult(t *testing.T) {
+	testCases := []struct {
+		name        string
+		in          *updater.CheckResult
+		wantMessage string
+		wantPackage bool
+	}{
+		{
+			name:        "nil結果",
+			in:          nil,
+			wantMessage: "マネージャ本体更新を確認しました（DryRunモード）",
+		},
+		{
+			name: "更新ありでメッセージなし",
+			in: &updater.CheckResult{
+				AvailableUpdates: 1,
+				Packages:         []updater.PackageInfo{{Name: "uv"}},
+			},
+			wantMessage: "1 件のマネージャ本体更新が可能です（DryRunモード）",
+			wantPackage: true,
+		},
+		{
+			name: "更新ありでメッセージあり",
+			in: &updater.CheckResult{
+				AvailableUpdates: 1,
+				Message:          "uv 本体の更新が可能です",
+			},
+			wantMessage: "uv 本体の更新が可能です（DryRunモード）",
+		},
+		{
+			name:        "更新なしでメッセージなし",
+			in:          &updater.CheckResult{},
+			wantMessage: "マネージャ本体は最新です（DryRunモード）",
+		},
+		{
+			name: "更新なしでメッセージあり",
+			in: &updater.CheckResult{
+				Message: "uv 本体は最新です",
+			},
+			wantMessage: "uv 本体は最新です（DryRunモード）",
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got := buildDryRunSelfUpdateResult(tc.in)
+
+			if got.Message != tc.wantMessage {
+				t.Fatalf("Message = %q, want %q", got.Message, tc.wantMessage)
+			}
+
+			if got.Continuation != updater.ContinueNormalUpdate {
+				t.Fatalf("Continuation = %q, want continue", got.Continuation)
+			}
+
+			if tc.wantPackage && len(got.Packages) != 1 {
+				t.Fatalf("Packages length = %d, want 1", len(got.Packages))
+			}
+		})
+	}
+}
+
+func TestExecuteManagerSelfUpdate(t *testing.T) {
+	t.Run("DryRunの確認エラーを返す", func(t *testing.T) {
+		selfUpdater := &selfUpdateStubUpdater{
+			stubUpdater: stubUpdater{name: "uv"},
+			checkErr:    errors.New("check failed"),
+		}
+
+		got, err := executeManagerSelfUpdate(context.Background(), selfUpdater, updater.UpdateOptions{DryRun: true})
+
+		if err == nil || !strings.Contains(err.Error(), "check failed") {
+			t.Fatalf("err = %v, want check failed", err)
+		}
+
+		if got != nil {
+			t.Fatalf("result = %+v, want nil", got)
+		}
+
+		if selfUpdater.checkCalls != 1 || selfUpdater.selfCalls != 0 {
+			t.Fatalf("calls = check:%d self:%d, want check:1 self:0", selfUpdater.checkCalls, selfUpdater.selfCalls)
+		}
+	})
+
+	t.Run("通常実行でnil結果なら継続扱いにする", func(t *testing.T) {
+		selfUpdater := &selfUpdateStubUpdater{
+			stubUpdater: stubUpdater{name: "uv"},
+			nilSelf:     true,
+		}
+
+		got, err := executeManagerSelfUpdate(context.Background(), selfUpdater, updater.UpdateOptions{})
+		if err != nil {
+			t.Fatalf("err = %v, want nil", err)
+		}
+
+		if got == nil || got.Continuation != updater.ContinueNormalUpdate {
+			t.Fatalf("result = %+v, want continue result", got)
+		}
+
+		if selfUpdater.checkCalls != 0 || selfUpdater.selfCalls != 1 {
+			t.Fatalf("calls = check:%d self:%d, want check:0 self:1", selfUpdater.checkCalls, selfUpdater.selfCalls)
+		}
+	})
+}
+
+func TestMergeSelfUpdateResult(t *testing.T) {
+	stats := updateStats{Updated: 1}
+
+	mergeSelfUpdateResult(&stats, nil)
+
+	if stats.Updated != 1 || stats.Failed != 0 || len(stats.Errors) != 0 {
+		t.Fatalf("nil merge stats = %+v, want unchanged", stats)
+	}
+
+	mergeSelfUpdateResult(&stats, &updater.SelfUpdateResult{
+		UpdateResult: updater.UpdateResult{
+			UpdatedCount: 2,
+			FailedCount:  1,
+			Errors:       []error{errors.New("failed")},
+		},
+	})
+
+	if stats.Updated != 3 || stats.Failed != 1 || len(stats.Errors) != 1 {
+		t.Fatalf("merged stats = %+v, want updated:3 failed:1 errors:1", stats)
+	}
+}
+
+func TestFilterNormalUpdateUpdaters(t *testing.T) {
+	updaters := []updater.Updater{
+		stubUpdater{name: "uv"},
+		stubUpdater{name: "npm"},
+	}
+
+	if got := filterNormalUpdateUpdaters(updaters, nil); len(got) != 2 {
+		t.Fatalf("no skip length = %d, want 2", len(got))
+	}
+
+	got := filterNormalUpdateUpdaters(updaters, map[string]bool{"uv": true})
+	if strings.Join(updaterNames(got), ",") != "npm" {
+		t.Fatalf("filtered = %v, want [npm]", updaterNames(got))
+	}
+}
+
+func updaterNames(updaters []updater.Updater) []string {
+	names := make([]string, 0, len(updaters))
+	for _, u := range updaters {
+		names = append(names, u.Name())
+	}
+
+	return names
 }
 
 func TestSplitUpdatersForExecution(t *testing.T) {

--- a/docs/Implementation_Plan.md
+++ b/docs/Implementation_Plan.md
@@ -132,5 +132,6 @@ secrets:
   - 進捗（第1弾）: `flatpak` / `fwupdmgr` を追加し、`config init` / `sys list` / README の対応マネージャ表記を更新済み
   - 進捗（第2弾）: `pnpm` / `nvm` を追加し、`config init` / `sys update` / README の対応マネージャ表記を更新済み
   - 進捗（第3弾）: `uv tool` / `rustup` / `gem` を追加し、`config init` / `sys list` / README の対応マネージャ表記を更新済み
-  - 残件（第4弾以降）: `winget` / `scoop` と統合テスト
+  - 進捗（第4弾）: `sys update` にマネージャ本体更新フェーズを追加し、`uv self update` と `pnpm update -g --latest` に対応
+  - 残件（第5弾以降）: `winget` / `scoop` と統合テスト
 - [ ] リリース/CI（GoReleaser/GitHub Actions/E2E）

--- a/internal/updater/pnpm.go
+++ b/internal/updater/pnpm.go
@@ -131,7 +131,7 @@ func (p *PnpmUpdater) Update(ctx context.Context, opts UpdateOptions) (*UpdateRe
 	if err := p.runUpdate(ctx); err != nil {
 		result.Errors = append(result.Errors, err)
 
-		return result, fmt.Errorf("pnpm update -g に失敗: %w", err)
+		return result, fmt.Errorf("pnpm update -g --latest に失敗: %w", err)
 	}
 
 	result.UpdatedCount = checkResult.AvailableUpdates
@@ -142,7 +142,7 @@ func (p *PnpmUpdater) Update(ctx context.Context, opts UpdateOptions) (*UpdateRe
 }
 
 func (p *PnpmUpdater) runUpdate(ctx context.Context) error {
-	cmd := exec.CommandContext(ctx, "pnpm", "update", "-g")
+	cmd := exec.CommandContext(ctx, "pnpm", "update", "-g", "--latest")
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.Stdin = os.Stdin

--- a/internal/updater/pnpm_test.go
+++ b/internal/updater/pnpm_test.go
@@ -510,6 +510,13 @@ func TestPnpmUpdater_Update(t *testing.T) {
 			wantMessageContains:   "更新確認をスキップしました",
 			expectManifestMissing: true,
 		},
+		{
+			name:        "通常更新失敗",
+			mode:        "update_fail",
+			opts:        UpdateOptions{},
+			expectErr:   true,
+			errContains: "pnpm update -g --latest に失敗",
+		},
 	}
 
 	for _, tc := range tests {
@@ -654,8 +661,7 @@ if "%subcmd%"=="update" (
     exit /b 1
   )
   if "%DSX_TEST_PNPM_MODE%"=="update_fail" (
-    >&2 echo update failed
-    exit /b 1
+    goto updatefail
   )
   echo updated
   exit /b 0
@@ -663,6 +669,10 @@ if "%subcmd%"=="update" (
 
 echo []
 exit /b 0
+
+:updatefail
+>&2 echo update failed
+exit /b 1
 `
 	} else {
 		fileName = "pnpm"

--- a/internal/updater/pnpm_test.go
+++ b/internal/updater/pnpm_test.go
@@ -645,6 +645,14 @@ if "%subcmd%"=="outdated" (
 )
 
 if "%subcmd%"=="update" (
+  if not "%2"=="-g" (
+    >&2 echo missing -g
+    exit /b 1
+  )
+  if not "%3"=="--latest" (
+    >&2 echo missing --latest
+    exit /b 1
+  )
   if "%DSX_TEST_PNPM_MODE%"=="update_fail" (
     >&2 echo update failed
     exit /b 1
@@ -716,6 +724,14 @@ if [ "${subcmd}" = "outdated" ]; then
 fi
 
 if [ "${subcmd}" = "update" ]; then
+  if [ "$2" != "-g" ]; then
+    echo 'missing -g' 1>&2
+    exit 1
+  fi
+  if [ "$3" != "--latest" ]; then
+    echo 'missing --latest' 1>&2
+    exit 1
+  fi
   if [ "${mode}" = "update_fail" ]; then
     echo 'update failed' 1>&2
     exit 1

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -38,6 +38,38 @@ type Updater interface {
 	Configure(cfg config.ManagerConfig) error
 }
 
+// ManagerSelfUpdater はマネージャ本体を更新できるUpdaterが追加で実装する任意インターフェースです。
+// Updater.Update は配下ツールやパッケージの更新に専念し、マネージャ本体更新は sys update の前段フェーズで扱います。
+type ManagerSelfUpdater interface {
+	// CheckSelfUpdate はマネージャ本体の更新可否を副作用なしで確認します。
+	CheckSelfUpdate(ctx context.Context) (*CheckResult, error)
+
+	// SelfUpdate はマネージャ本体の更新を実行します。
+	SelfUpdate(ctx context.Context, opts UpdateOptions) (*SelfUpdateResult, error)
+}
+
+// SelfUpdateContinuation はマネージャ本体更新後に通常更新フェーズへ進むかを表します。
+type SelfUpdateContinuation string
+
+const (
+	// ContinueNormalUpdate は本体更新後も通常更新フェーズを継続します。
+	ContinueNormalUpdate SelfUpdateContinuation = "continue"
+	// SkipNormalUpdate は本体更新後に同じマネージャの通常更新フェーズをスキップします。
+	SkipNormalUpdate SelfUpdateContinuation = "skip"
+)
+
+// SelfUpdateResult はマネージャ本体更新の結果です。
+type SelfUpdateResult struct {
+	UpdateResult
+	Continuation SelfUpdateContinuation
+}
+
+// ShouldContinueNormalUpdate は通常更新フェーズへ進むべきかを返します。
+// Continuation 未設定の実装は既存挙動を壊さないよう継続扱いにします。
+func (r *SelfUpdateResult) ShouldContinueNormalUpdate() bool {
+	return r == nil || r.Continuation != SkipNormalUpdate
+}
+
 // CheckResult は更新確認の結果を保持します。
 type CheckResult struct {
 	// AvailableUpdates は更新可能なパッケージ数

--- a/internal/updater/updater_test.go
+++ b/internal/updater/updater_test.go
@@ -40,6 +40,43 @@ func clearRegistry() {
 	globalRegistry.mu.Unlock()
 }
 
+func TestSelfUpdateResult_ShouldContinueNormalUpdate(t *testing.T) {
+	testCases := []struct {
+		name string
+		in   *SelfUpdateResult
+		want bool
+	}{
+		{
+			name: "nilは通常更新を継続",
+			in:   nil,
+			want: true,
+		},
+		{
+			name: "Continuation未設定は通常更新を継続",
+			in:   &SelfUpdateResult{},
+			want: true,
+		},
+		{
+			name: "ContinueNormalUpdateは通常更新を継続",
+			in:   &SelfUpdateResult{Continuation: ContinueNormalUpdate},
+			want: true,
+		},
+		{
+			name: "SkipNormalUpdateは通常更新をスキップ",
+			in:   &SelfUpdateResult{Continuation: SkipNormalUpdate},
+			want: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.in.ShouldContinueNormalUpdate()
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
 func TestRegisterAndGet(t *testing.T) {
 	t.Run("正常系: Updaterを登録して取得", func(t *testing.T) {
 		clearRegistry()

--- a/internal/updater/uv.go
+++ b/internal/updater/uv.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"regexp"
 	"strings"
 
 	"github.com/scottlz0310/dsx/internal/config"
@@ -13,6 +14,10 @@ import (
 
 // UVUpdater は uv tool (Python CLI ツール) の実装です。
 type UVUpdater struct{}
+
+var uvSelfUpdatePattern = regexp.MustCompile(`(?i)would update uv from v?(\S+) to v?(\S+)`)
+
+const uvSelfUpdateUnavailableMessage = "uv 本体の self update はこのインストール経路では利用できないためスキップします"
 
 // 起動時にレジストリに登録
 func init() {
@@ -61,6 +66,76 @@ func (u *UVUpdater) Check(ctx context.Context) (*CheckResult, error) {
 	}, nil
 }
 
+func (u *UVUpdater) CheckSelfUpdate(ctx context.Context) (*CheckResult, error) {
+	output, err := u.runSelfUpdateDryRun(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if isUVSelfUpdateUnsupportedOutput(output) {
+		return &CheckResult{
+			Message: uvSelfUpdateUnavailableMessage,
+		}, nil
+	}
+
+	packages := u.parseSelfUpdateDryRunOutput(output)
+	if len(packages) == 0 {
+		return &CheckResult{
+			Message: "uv 本体は最新です",
+		}, nil
+	}
+
+	return &CheckResult{
+		AvailableUpdates: len(packages),
+		Packages:         packages,
+		Message:          "uv 本体の更新が可能です",
+	}, nil
+}
+
+func (u *UVUpdater) SelfUpdate(ctx context.Context, opts UpdateOptions) (*SelfUpdateResult, error) {
+	checkResult, err := u.CheckSelfUpdate(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	result := &SelfUpdateResult{
+		Continuation: ContinueNormalUpdate,
+	}
+
+	if checkResult.AvailableUpdates == 0 {
+		result.Message = checkResult.Message
+		if result.Message == "" {
+			result.Message = "uv 本体は最新です"
+		}
+
+		return result, nil
+	}
+
+	if opts.DryRun {
+		result.Packages = checkResult.Packages
+		result.Message = "uv 本体の更新が可能です（DryRunモード）"
+
+		return result, nil
+	}
+
+	cmd := exec.CommandContext(ctx, "uv", "self", "update")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Stdin = os.Stdin
+
+	if err := cmd.Run(); err != nil {
+		result.Errors = append(result.Errors, err)
+
+		return result, fmt.Errorf("uv self update に失敗: %w", err)
+	}
+
+	result.UpdatedCount = checkResult.AvailableUpdates
+	result.Packages = checkResult.Packages
+	result.Message = "uv 本体を更新しました"
+
+	return result, nil
+}
+
 func (u *UVUpdater) Update(ctx context.Context, opts UpdateOptions) (*UpdateResult, error) {
 	result := &UpdateResult{}
 
@@ -98,6 +173,32 @@ func (u *UVUpdater) Update(ctx context.Context, opts UpdateOptions) (*UpdateResu
 	return result, nil
 }
 
+func (u *UVUpdater) runSelfUpdateDryRun(ctx context.Context) (string, error) {
+	cmd := exec.CommandContext(ctx, "uv", "self", "update", "--dry-run")
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		outputText := string(output)
+		if isUVSelfUpdateUnsupportedOutput(outputText) {
+			return outputText, nil
+		}
+
+		return "", fmt.Errorf(
+			"uv self update --dry-run の実行に失敗: %w",
+			buildCommandOutputErr(err, output),
+		)
+	}
+
+	return string(output), nil
+}
+
+func isUVSelfUpdateUnsupportedOutput(output string) bool {
+	lower := strings.ToLower(output)
+
+	return strings.Contains(lower, "self-update is only available") ||
+		strings.Contains(lower, "self-updates are disabled")
+}
+
 func (u *UVUpdater) parseToolListOutput(output string) []PackageInfo {
 	lines := strings.Split(output, "\n")
 	packages := make([]PackageInfo, 0, len(lines))
@@ -129,6 +230,21 @@ func (u *UVUpdater) parseToolListOutput(output string) []PackageInfo {
 	}
 
 	return packages
+}
+
+func (u *UVUpdater) parseSelfUpdateDryRunOutput(output string) []PackageInfo {
+	matches := uvSelfUpdatePattern.FindStringSubmatch(output)
+	if len(matches) != 3 {
+		return []PackageInfo{}
+	}
+
+	return []PackageInfo{
+		{
+			Name:           "uv",
+			CurrentVersion: strings.TrimPrefix(matches[1], "v"),
+			NewVersion:     strings.TrimPrefix(matches[2], "v"),
+		},
+	}
 }
 
 func parseToolLine(line string) (name, version string, ok bool) {

--- a/internal/updater/uv_test.go
+++ b/internal/updater/uv_test.go
@@ -87,6 +87,50 @@ pkg 1.2.3 (/tmp/path)
 	}
 }
 
+func TestUVUpdater_parseSelfUpdateDryRunOutput(t *testing.T) {
+	testCases := []struct {
+		name   string
+		output string
+		want   []PackageInfo
+	}{
+		{
+			name:   "更新あり",
+			output: "info: Checking for updates...\nWould update uv from v0.11.16 to v0.11.17\n",
+			want: []PackageInfo{
+				{Name: "uv", CurrentVersion: "0.11.16", NewVersion: "0.11.17"},
+			},
+		},
+		{
+			name:   "vなしでも解析する",
+			output: "Would update uv from 0.11.16 to 0.11.17\n",
+			want: []PackageInfo{
+				{Name: "uv", CurrentVersion: "0.11.16", NewVersion: "0.11.17"},
+			},
+		},
+		{
+			name:   "最新版",
+			output: "uv is already up-to-date\n",
+			want:   []PackageInfo{},
+		},
+		{
+			name:   "空出力",
+			output: "",
+			want:   []PackageInfo{},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			u := &UVUpdater{}
+			got := u.parseSelfUpdateDryRunOutput(tc.output)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
 func TestUVUpdater_Check(t *testing.T) {
 	testCases := []struct {
 		name        string
@@ -147,6 +191,76 @@ func TestUVUpdater_Check(t *testing.T) {
 
 			assert.NoError(t, err)
 			assert.Equal(t, tc.wantUpdates, got.AvailableUpdates)
+		})
+	}
+}
+
+func TestUVUpdater_CheckSelfUpdate(t *testing.T) {
+	testCases := []struct {
+		name        string
+		mode        string
+		wantUpdates int
+		wantPackage PackageInfo
+		wantErr     bool
+		errContains string
+		msgContains string
+	}{
+		{
+			name:        "本体更新あり",
+			mode:        "self_update_available",
+			wantUpdates: 1,
+			wantPackage: PackageInfo{Name: "uv", CurrentVersion: "0.11.16", NewVersion: "0.11.17"},
+			msgContains: "更新が可能",
+		},
+		{
+			name:        "本体は最新版",
+			mode:        "self_latest",
+			wantUpdates: 0,
+			msgContains: "最新",
+		},
+		{
+			name:        "dry-run失敗",
+			mode:        "self_error",
+			wantErr:     true,
+			errContains: "uv self update --dry-run の実行に失敗",
+		},
+		{
+			name:        "self update非対応のインストール経路はスキップ",
+			mode:        "self_unsupported",
+			wantUpdates: 0,
+			msgContains: "利用できない",
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			fakeDir := t.TempDir()
+			writeFakeUVCommand(t, fakeDir)
+
+			t.Setenv("PATH", fakeDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+			t.Setenv("DSX_TEST_UV_MODE", tc.mode)
+
+			u := &UVUpdater{}
+			got, err := u.CheckSelfUpdate(context.Background())
+
+			if tc.wantErr {
+				assert.Error(t, err)
+
+				if tc.errContains != "" && err != nil {
+					assert.Contains(t, err.Error(), tc.errContains)
+				}
+
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, tc.wantUpdates, got.AvailableUpdates)
+			assert.Contains(t, got.Message, tc.msgContains)
+
+			if tc.wantUpdates > 0 {
+				assert.Equal(t, []PackageInfo{tc.wantPackage}, got.Packages)
+			}
 		})
 	}
 }
@@ -229,6 +343,88 @@ func TestUVUpdater_Update(t *testing.T) {
 	}
 }
 
+func TestUVUpdater_SelfUpdate(t *testing.T) {
+	testCases := []struct {
+		name        string
+		mode        string
+		opts        UpdateOptions
+		wantUpdated int
+		wantErr     bool
+		errContains string
+		msgContains string
+	}{
+		{
+			name:        "DryRunは実更新せず計画表示",
+			mode:        "self_update_available",
+			opts:        UpdateOptions{DryRun: true},
+			wantUpdated: 0,
+			msgContains: "DryRun",
+		},
+		{
+			name:        "本体は最新版",
+			mode:        "self_latest",
+			opts:        UpdateOptions{},
+			wantUpdated: 0,
+			msgContains: "最新",
+		},
+		{
+			name:        "本体更新成功",
+			mode:        "self_update_available",
+			opts:        UpdateOptions{},
+			wantUpdated: 1,
+			msgContains: "uv 本体を更新しました",
+		},
+		{
+			name:        "本体更新失敗",
+			mode:        "self_update_error",
+			opts:        UpdateOptions{},
+			wantErr:     true,
+			errContains: "uv self update に失敗",
+		},
+		{
+			name:        "self update非対応のインストール経路はエラーにしない",
+			mode:        "self_unsupported",
+			opts:        UpdateOptions{},
+			wantUpdated: 0,
+			msgContains: "利用できない",
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			fakeDir := t.TempDir()
+			writeFakeUVCommand(t, fakeDir)
+
+			t.Setenv("PATH", fakeDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+			t.Setenv("DSX_TEST_UV_MODE", tc.mode)
+
+			u := &UVUpdater{}
+			got, err := u.SelfUpdate(context.Background(), tc.opts)
+
+			if tc.wantErr {
+				assert.Error(t, err)
+				assert.NotNil(t, got)
+
+				if tc.errContains != "" && err != nil {
+					assert.Contains(t, err.Error(), tc.errContains)
+				}
+
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.NotNil(t, got)
+			assert.Equal(t, tc.wantUpdated, got.UpdatedCount)
+			assert.Equal(t, ContinueNormalUpdate, got.Continuation)
+
+			if tc.msgContains != "" {
+				assert.Contains(t, got.Message, tc.msgContains)
+			}
+		})
+	}
+}
+
 func writeFakeUVCommand(t *testing.T, dir string) {
 	t.Helper()
 
@@ -243,6 +439,7 @@ func writeFakeUVCommand(t *testing.T, dir string) {
 set mode=%DSX_TEST_UV_MODE%
 if "%1"=="tool" if "%2"=="list" goto list
 if "%1"=="tool" if "%2"=="upgrade" goto upgrade
+if "%1"=="self" if "%2"=="update" goto selfupdate
 >&2 echo invalid args
 exit /b 1
 :list
@@ -264,6 +461,30 @@ if "%mode%"=="update_error" (
   >&2 echo uv tool upgrade failed
   exit /b 1
 )
+exit /b 0
+:selfupdate
+if "%3"=="--dry-run" goto selfupdatedryrun
+if "%mode%"=="self_update_error" (
+  >&2 echo uv self update failed
+  exit /b 1
+)
+exit /b 0
+:selfupdatedryrun
+if "%mode%"=="self_error" goto selferror
+if "%mode%"=="self_unsupported" goto selfunsupported
+if "%mode%"=="self_update_available" if not "%DSX_TEST_UV_SELF_UPDATED%"=="1" goto selfavailable
+if "%mode%"=="self_update_error" goto selfavailable
+echo uv is already up-to-date
+exit /b 0
+:selferror
+echo uv self update dry-run failed 1>&2
+exit /b 1
+:selfunsupported
+echo warning: Self-update is only available for uv binaries installed via the standalone installation scripts. 1>&2
+exit /b 1
+:selfavailable
+echo info: Checking for updates...
+echo Would update uv from v0.11.16 to v0.11.17
 exit /b 0
 `
 	} else {
@@ -288,6 +509,35 @@ fi
 if [ "$1" = "tool" ] && [ "$2" = "upgrade" ]; then
   if [ "${mode}" = "update_error" ]; then
     echo "uv tool upgrade failed" 1>&2
+    exit 1
+  fi
+  exit 0
+fi
+if [ "$1" = "self" ] && [ "$2" = "update" ]; then
+  if [ "$3" = "--dry-run" ]; then
+    if [ "${mode}" = "self_error" ]; then
+      echo "uv self update dry-run failed" 1>&2
+      exit 1
+    fi
+    if [ "${mode}" = "self_unsupported" ]; then
+      echo "warning: Self-update is only available for uv binaries installed via the standalone installation scripts." 1>&2
+      exit 1
+    fi
+    if [ "${mode}" = "self_update_available" ] && [ "${DSX_TEST_UV_SELF_UPDATED}" != "1" ]; then
+      echo "info: Checking for updates..."
+      echo "Would update uv from v0.11.16 to v0.11.17"
+      exit 0
+    fi
+    if [ "${mode}" = "self_update_error" ]; then
+      echo "info: Checking for updates..."
+      echo "Would update uv from v0.11.16 to v0.11.17"
+      exit 0
+    fi
+    echo "uv is already up-to-date"
+    exit 0
+  fi
+  if [ "${mode}" = "self_update_error" ]; then
+    echo "uv self update failed" 1>&2
     exit 1
   fi
   exit 0

--- a/tasks.md
+++ b/tasks.md
@@ -250,6 +250,19 @@
 
 ---
 
+## Issue #81: sys update マネージャ本体更新フェーズ
+
+- [x] `ManagerSelfUpdater` / `CheckSelfUpdate` / `SelfUpdate` を追加し、既存 `Updater` インターフェースを壊さない拡張点を用意
+- [x] `sys update` の中央実行フローに「マネージャ本体更新フェーズ → 通常更新フェーズ」を追加
+- [x] `uv` updater で `uv self update --dry-run` / `uv self update` に対応
+- [x] `uv self update` 非対応のインストール経路では本体更新をスキップし、通常更新フェーズを継続
+- [x] `pnpm` のグローバル更新を `pnpm update -g --latest` に変更
+- [x] dry-run が `SelfUpdate` ではなく `CheckSelfUpdate` のみを呼ぶことをテストで固定
+- [x] self update 後に通常更新を継続するかスキップするかを `SelfUpdateContinuation` で表現し、スキップ時の挙動をテストで固定
+- [x] `CHANGELOG.md` / `README.md` / `docs/Implementation_Plan.md` を更新
+
+---
+
 ## Backlog / 改善候補
 
 ### `AutoStash` オプションの修正（設定が機能していないバグ）


### PR DESCRIPTION
## 概要

Issue #81 に対応し、`dsx sys update` に「マネージャ本体更新フェーズ → 通常更新フェーズ」の実行順を追加しました。

- `ManagerSelfUpdater` / `CheckSelfUpdate` / `SelfUpdate` を追加し、既存 `Updater` インターフェースを壊さずに本体更新を拡張できるようにした
- `uv` updater で `uv self update --dry-run` / `uv self update` に対応した
- `uv self update` が利用できないインストール経路では、本体更新をスキップして通常更新フェーズを継続する
- `pnpm` のグローバル更新を `pnpm update -g --latest` に変更した
- `CHANGELOG.md` / `README.md` / `docs/Implementation_Plan.md` / `tasks.md` を更新した

## 設計メモ

`dry-run` は中央フローで `CheckSelfUpdate` のみを呼び、`SelfUpdate` を呼ばないようにしています。これにより、本体更新フェーズでも副作用なしの予定表示を保証します。

self update 後に通常更新へ進むかどうかは `SelfUpdateContinuation` で表現し、今後マネージャを追加するときに挙動がぶれないようにしました。

`dsx` 本体更新はこのフェーズに含めず、従来通り `dsx self-update` の責務として分離しています。

## リリース観点

機能追加を含むため、リリース時は v0.7.0 相当のバージョンバンプ候補として扱う想定です。README の現在バージョン表記は、実際のリリース準備 PR またはタグ発行時に更新する前提で据え置いています。

## 検証

- `task check`
- `go build ./...`
- `go run ./cmd/dsx --help`
- push 時の pre-push hook（lint / test）

Closes #81
