### PR TITLE
feat: Bun のグローバル更新に対応

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- `dsx sys update` に Bun updater を追加。`bun outdated -g` / `bun update -g --latest` によるグローバルパッケージ更新と、Bun 管理のインストールに対する `bun upgrade` に対応し、Homebrew / Scoop 管理下または所有元不明の本体更新は安全にスキップする（#96）
+
 ## [v0.7.0] - 2026-05-30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ dsx sys discover              # インストール済み Go バイナリを検�
 dsx sys discover --manager go # Go バイナリのみスキャン
 ```
 
-**対応パッケージマネージャ**: apt, brew, go, npm, pnpm, nvm, snap, flatpak, fwupdmgr, pipx, cargo, uv, rustup, gem, winget, scoop
+**対応パッケージマネージャ**: apt, brew, go, npm, pnpm, bun, nvm, snap, flatpak, fwupdmgr, pipx, cargo, uv, rustup, gem, winget, scoop
 
 `sys update` は `--jobs / -j` で並列数を指定できます（未指定時は `config.yaml` の `control.concurrency` を使用）。
 `apt` はパッケージロック競合を避けるため、依存関係ルールとして単独実行されます。
@@ -190,6 +190,9 @@ dsx sys discover --manager go # Go バイナリのみスキャン
 `sys update` は対応マネージャについて「マネージャ本体更新フェーズ」→「通常更新フェーズ」の順に実行します。
 たとえば `uv` は `uv self update` で uv 本体を確認・更新してから、通常更新フェーズで `uv tool upgrade --all` を実行します。
 `uv self update` が利用できないインストール経路では、uv 本体更新はスキップし、通常更新フェーズを継続します。
+`bun` は Bun 管理のインストールでは `bun upgrade` で本体を更新してから、`bun update -g --latest` でグローバルパッケージを latest まで更新します。
+Homebrew / Scoop 管理下または所有元を安全に判定できない Bun は本体更新をスキップし、グローバルパッケージ更新のみ継続します。
+Bun updater は Homebrew / Scoop による本体更新との競合を避けるため、通常更新の並列フェーズより先に単独実行します。
 `dsx` 本体はこのフェーズでは更新せず、従来通り `dsx self-update` で扱います。
 `pnpm` のグローバル更新は `pnpm update -g --latest` を使用し、version range に制限されず latest まで更新します。
 

--- a/cmd/dsx/config.go
+++ b/cmd/dsx/config.go
@@ -36,7 +36,7 @@ const (
 var errConfigInitCanceled = errors.New("config init canceled")
 
 var availableSystemManagers = []string{
-	"apt", "brew", "go", "npm", "pnpm", "nvm", "snap", "flatpak", "fwupdmgr", "pipx", "cargo", "uv", "rustup", "gem", "winget", "scoop",
+	"apt", "brew", "go", "npm", "pnpm", "bun", "nvm", "snap", "flatpak", "fwupdmgr", "pipx", "cargo", "uv", "rustup", "gem", "winget", "scoop",
 }
 
 // テストで対話入力や外部依存を差し替えるためのフック

--- a/cmd/dsx/config_test.go
+++ b/cmd/dsx/config_test.go
@@ -345,7 +345,7 @@ func TestBuildConfigInitDefaults(t *testing.T) {
 	t.Parallel()
 
 	promptOptions := []string{
-		"apt", "brew", "go", "npm", "pnpm", "nvm", "snap", "flatpak", "fwupdmgr", "pipx", "cargo", "uv", "rustup", "gem",
+		"apt", "brew", "go", "npm", "pnpm", "bun", "nvm", "snap", "flatpak", "fwupdmgr", "pipx", "cargo", "uv", "rustup", "gem",
 	}
 
 	testCases := []struct {

--- a/cmd/dsx/sys.go
+++ b/cmd/dsx/sys.go
@@ -46,6 +46,7 @@ var sysUpdateCmd = &cobra.Command{
   - go        (Go ツール)
   - npm       (Node.js グローバルパッケージ)
   - pnpm      (Node.js グローバルパッケージ)
+  - bun       (JavaScript/TypeScript グローバルパッケージ)
   - nvm       (Node.js バージョン管理)
   - snap      (Ubuntu Snap パッケージ)
   - flatpak   (Linux Flatpak)
@@ -710,7 +711,8 @@ func isContextCancellation(err error) bool {
 }
 
 func mustRunExclusively(u updater.Updater) bool {
-	return u.Name() == "apt"
+	// Bun 本体が Homebrew / Scoop 管理の場合、所有元の更新と bun update -g の競合を避けます。
+	return u.Name() == "apt" || u.Name() == "bun"
 }
 
 func mergeUpdateStats(dst *updateStats, src updateStats) {

--- a/cmd/dsx/sys_test.go
+++ b/cmd/dsx/sys_test.go
@@ -546,17 +546,18 @@ func TestSplitUpdatersForExecution(t *testing.T) {
 	input := []updater.Updater{
 		stubUpdater{name: "brew"},
 		stubUpdater{name: "apt"},
+		stubUpdater{name: "bun"},
 		stubUpdater{name: "go"},
 	}
 
 	exclusive, parallel := splitUpdatersForExecution(input)
 
-	if len(exclusive) != 1 {
-		t.Fatalf("exclusive length = %d, want 1", len(exclusive))
+	if len(exclusive) != 2 {
+		t.Fatalf("exclusive length = %d, want 2", len(exclusive))
 	}
 
-	if exclusive[0].Name() != "apt" {
-		t.Fatalf("exclusive[0] = %s, want apt", exclusive[0].Name())
+	if exclusive[0].Name() != "apt" || exclusive[1].Name() != "bun" {
+		t.Fatalf("exclusive order = [%s, %s], want [apt, bun]", exclusive[0].Name(), exclusive[1].Name())
 	}
 
 	if len(parallel) != 2 {
@@ -585,6 +586,11 @@ func TestMustRunExclusively(t *testing.T) {
 			name: "brewは並列可",
 			in:   stubUpdater{name: "brew"},
 			want: false,
+		},
+		{
+			name: "bunは所有元の更新との競合回避のため単独実行",
+			in:   stubUpdater{name: "bun"},
+			want: true,
 		},
 	}
 

--- a/docs/Implementation_Plan.md
+++ b/docs/Implementation_Plan.md
@@ -133,5 +133,6 @@ secrets:
   - 進捗（第2弾）: `pnpm` / `nvm` を追加し、`config init` / `sys update` / README の対応マネージャ表記を更新済み
   - 進捗（第3弾）: `uv tool` / `rustup` / `gem` を追加し、`config init` / `sys list` / README の対応マネージャ表記を更新済み
   - 進捗（第4弾）: `sys update` にマネージャ本体更新フェーズを追加し、`uv self update` と `pnpm update -g --latest` に対応
-  - 残件（第5弾以降）: `winget` / `scoop` と統合テスト
+  - 進捗（第5弾）: `bun` を追加し、グローバルパッケージ更新とインストール経路に応じた Bun 本体更新に対応
+  - 残件（第6弾以降）: 統合テスト
 - [ ] リリース/CI（GoReleaser/GitHub Actions/E2E）

--- a/internal/selfupdate/selfupdate.go
+++ b/internal/selfupdate/selfupdate.go
@@ -110,13 +110,18 @@ func CheckAvailable(ctx context.Context, currentVersion string, fetch ReleaseFet
 
 // FetchLatestRelease は GitHub Releases API から最新リリースタグを取得します。
 func FetchLatestRelease(ctx context.Context, userAgentVersion string) (latestVersion, releaseURL string, err error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, latestReleaseAPIURL, http.NoBody)
+	return FetchGitHubLatestRelease(ctx, latestReleaseAPIURL, "dsx/"+strings.TrimSpace(userAgentVersion))
+}
+
+// FetchGitHubLatestRelease は指定した GitHub Releases API から最新リリースタグを取得します。
+func FetchGitHubLatestRelease(ctx context.Context, apiURL, userAgent string) (latestVersion, releaseURL string, err error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, http.NoBody)
 	if err != nil {
 		return "", "", err
 	}
 
 	req.Header.Set("Accept", "application/vnd.github+json")
-	req.Header.Set("User-Agent", "dsx/"+strings.TrimSpace(userAgentVersion))
+	req.Header.Set("User-Agent", strings.TrimSpace(userAgent))
 
 	client := latestReleaseHTTPClient
 	if client == nil {

--- a/internal/updater/apt.go
+++ b/internal/updater/apt.go
@@ -95,7 +95,7 @@ func (a *AptUpdater) Update(ctx context.Context, opts UpdateOptions) (*UpdateRes
 	}
 
 	// 実際の更新を実行
-	args := []string{"upgrade", "-y"}
+	args := []string{upgradeCommand, "-y"}
 	if err := a.runCommand(ctx, args...); err != nil {
 		result.Errors = append(result.Errors, err)
 		return result, fmt.Errorf("apt upgrade に失敗: %w", err)

--- a/internal/updater/brew.go
+++ b/internal/updater/brew.go
@@ -106,7 +106,7 @@ func (b *BrewUpdater) Update(ctx context.Context, opts UpdateOptions) (*UpdateRe
 	}
 
 	// フォーミュラの更新
-	upgradeCmd := exec.CommandContext(ctx, "brew", "upgrade")
+	upgradeCmd := exec.CommandContext(ctx, "brew", upgradeCommand)
 	upgradeCmd.Stdout = os.Stdout
 	upgradeCmd.Stderr = os.Stderr
 
@@ -115,7 +115,7 @@ func (b *BrewUpdater) Update(ctx context.Context, opts UpdateOptions) (*UpdateRe
 	}
 
 	// Cask の更新（greedy オプション考慮）
-	caskArgs := []string{"upgrade", "--cask"}
+	caskArgs := []string{upgradeCommand, "--cask"}
 	if b.greedy {
 		caskArgs = append(caskArgs, "--greedy")
 	}

--- a/internal/updater/bun.go
+++ b/internal/updater/bun.go
@@ -1,0 +1,439 @@
+package updater
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/scottlz0310/dsx/internal/config"
+	"github.com/scottlz0310/dsx/internal/selfupdate"
+)
+
+const (
+	bunLatestReleaseAPI = "https://api.github.com/repos/oven-sh/bun/releases/latest"
+
+	bunOwnerSelf     bunInstallOwner = "bun"
+	bunOwnerHomebrew bunInstallOwner = "homebrew"
+	bunOwnerScoop    bunInstallOwner = "scoop"
+	bunOwnerUnknown  bunInstallOwner = "unknown"
+)
+
+type bunInstallOwner string
+
+type bunReleaseFetcher func(context.Context, string) (latestVersion, releaseURL string, err error)
+type bunOutputRunner func(context.Context, ...string) ([]byte, error)
+type bunInteractiveRunner func(context.Context, ...string) error
+
+// BunUpdater は Bun のグローバルパッケージと Bun 本体を更新します。
+type BunUpdater struct {
+	lookPathStep       func(string) (string, error)
+	detectOwnerStep    func(string) bunInstallOwner
+	fetchReleaseStep   bunReleaseFetcher
+	runOutputStep      bunOutputRunner
+	runInteractiveStep bunInteractiveRunner
+}
+
+func init() {
+	Register(&BunUpdater{})
+}
+
+func (b *BunUpdater) Name() string {
+	return "bun"
+}
+
+func (b *BunUpdater) DisplayName() string {
+	return "Bun (JavaScript/TypeScript グローバルパッケージ)"
+}
+
+func (b *BunUpdater) IsAvailable() bool {
+	_, err := b.lookPath("bun")
+
+	return err == nil
+}
+
+func (b *BunUpdater) Configure(config.ManagerConfig) error {
+	return nil
+}
+
+func (b *BunUpdater) Check(ctx context.Context) (*CheckResult, error) {
+	output, err := b.runOutput(ctx, "outdated", "-g")
+	if err != nil {
+		return nil, fmt.Errorf("bun outdated -g の実行に失敗: %w", err)
+	}
+
+	packages, err := parseBunOutdatedOutput(string(output))
+	if err != nil {
+		return nil, fmt.Errorf("bun outdated -g の出力解析に失敗: %w", err)
+	}
+
+	return &CheckResult{
+		AvailableUpdates: len(packages),
+		Packages:         packages,
+	}, nil
+}
+
+func (b *BunUpdater) Update(ctx context.Context, opts UpdateOptions) (*UpdateResult, error) {
+	checkResult, err := b.Check(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	result := &UpdateResult{
+		Packages: checkResult.Packages,
+	}
+
+	if checkResult.AvailableUpdates == 0 {
+		result.Message = "すべての Bun グローバルパッケージは最新です"
+
+		return result, nil
+	}
+
+	if opts.DryRun {
+		result.Message = fmt.Sprintf("%d 件の Bun グローバルパッケージが更新可能です（DryRunモード）", checkResult.AvailableUpdates)
+
+		return result, nil
+	}
+
+	if err := b.runInteractive(ctx, "update", "-g", "--latest"); err != nil {
+		result.Errors = append(result.Errors, err)
+
+		return result, fmt.Errorf("bun update -g --latest に失敗: %w", err)
+	}
+
+	result.UpdatedCount = checkResult.AvailableUpdates
+	result.Message = fmt.Sprintf("%d 件の Bun グローバルパッケージを更新しました", result.UpdatedCount)
+
+	return result, nil
+}
+
+func (b *BunUpdater) CheckSelfUpdate(ctx context.Context) (*CheckResult, error) {
+	bunPath, err := b.lookPath("bun")
+	if err != nil {
+		return nil, fmt.Errorf("bun 実行ファイルの確認に失敗: %w", err)
+	}
+
+	owner := b.detectOwner(bunPath)
+	if owner != bunOwnerSelf {
+		return &CheckResult{Message: bunSelfUpdateSkipMessage(owner)}, nil
+	}
+
+	currentOutput, err := b.runOutput(ctx, "--version")
+	if err != nil {
+		return nil, fmt.Errorf("bun --version の実行に失敗: %w", err)
+	}
+
+	currentVersion := normalizeBunVersion(string(currentOutput))
+
+	currentCore, ok := selfupdate.ParseSemverCore(currentVersion)
+	if !ok {
+		return nil, fmt.Errorf("bun の現在バージョンを解析できません: %q", strings.TrimSpace(string(currentOutput)))
+	}
+
+	checkCtx, cancel := context.WithTimeout(ctx, selfupdate.CheckTimeout)
+	defer cancel()
+
+	latestVersion, _, err := b.fetchRelease(checkCtx, currentVersion)
+	if err != nil {
+		return nil, fmt.Errorf("bun の最新リリース取得に失敗: %w", err)
+	}
+
+	latestVersion = normalizeBunVersion(latestVersion)
+
+	latestCore, ok := selfupdate.ParseSemverCore(latestVersion)
+	if !ok {
+		return nil, fmt.Errorf("bun の最新バージョンを解析できません: %q", latestVersion)
+	}
+
+	if selfupdate.CompareSemverCore(latestCore, currentCore) <= 0 {
+		return &CheckResult{Message: "Bun 本体は最新です"}, nil
+	}
+
+	return &CheckResult{
+		AvailableUpdates: 1,
+		Packages: []PackageInfo{
+			{
+				Name:           "bun",
+				CurrentVersion: currentVersion,
+				NewVersion:     latestVersion,
+			},
+		},
+		Message: "Bun 本体の更新が可能です",
+	}, nil
+}
+
+func (b *BunUpdater) SelfUpdate(ctx context.Context, opts UpdateOptions) (*SelfUpdateResult, error) {
+	checkResult, err := b.CheckSelfUpdate(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	result := &SelfUpdateResult{
+		Continuation: ContinueNormalUpdate,
+		UpdateResult: UpdateResult{
+			Packages: checkResult.Packages,
+			Message:  checkResult.Message,
+		},
+	}
+
+	if checkResult.AvailableUpdates == 0 {
+		return result, nil
+	}
+
+	if opts.DryRun {
+		result.Message = "Bun 本体の更新が可能です（DryRunモード）"
+
+		return result, nil
+	}
+
+	if err := b.runInteractive(ctx, upgradeCommand); err != nil {
+		result.Errors = append(result.Errors, err)
+
+		return result, fmt.Errorf("bun upgrade に失敗: %w", err)
+	}
+
+	result.UpdatedCount = 1
+	result.Message = "Bun 本体を更新しました"
+
+	return result, nil
+}
+
+func parseBunOutdatedOutput(output string) ([]PackageInfo, error) {
+	lines := strings.Split(output, "\n")
+	packages := make([]PackageInfo, 0)
+	headerFound := false
+
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "bun outdated v") || isBunTableBorder(trimmed) {
+			continue
+		}
+
+		columns := splitBunTableRow(trimmed)
+		if !headerFound {
+			if isBunOutdatedHeader(columns) {
+				headerFound = true
+				continue
+			}
+
+			return nil, fmt.Errorf("ヘッダーを認識できません: %q", trimmed)
+		}
+
+		if len(columns) != 4 {
+			return nil, fmt.Errorf("列数が不正です: %q", trimmed)
+		}
+
+		if columns[0] == "" || columns[1] == "" || columns[3] == "" {
+			return nil, fmt.Errorf("必須列が空です: %q", trimmed)
+		}
+
+		packages = append(packages, PackageInfo{
+			Name:           columns[0],
+			CurrentVersion: columns[1],
+			NewVersion:     columns[3],
+		})
+	}
+
+	return packages, nil
+}
+
+func splitBunTableRow(line string) []string {
+	normalized := strings.ReplaceAll(line, "│", "|")
+	if !strings.HasPrefix(normalized, "|") || !strings.HasSuffix(normalized, "|") {
+		return nil
+	}
+
+	rawColumns := strings.Split(strings.Trim(normalized, "|"), "|")
+	columns := make([]string, 0, len(rawColumns))
+
+	for _, column := range rawColumns {
+		columns = append(columns, strings.TrimSpace(column))
+	}
+
+	return columns
+}
+
+func isBunOutdatedHeader(columns []string) bool {
+	return len(columns) == 4 &&
+		columns[0] == "Package" &&
+		columns[1] == "Current" &&
+		columns[2] == "Update" &&
+		columns[3] == "Latest"
+}
+
+func isBunTableBorder(line string) bool {
+	return strings.TrimFunc(line, func(r rune) bool {
+		switch r {
+		case '|', '-', '+', ' ', '┌', '┐', '└', '┘', '├', '┤', '┬', '┴', '┼', '─', '│':
+			return true
+		default:
+			return false
+		}
+	}) == ""
+}
+
+func normalizeBunVersion(version string) string {
+	normalized := strings.TrimSpace(version)
+	normalized = strings.TrimPrefix(normalized, "bun-")
+
+	return strings.TrimPrefix(normalized, "v")
+}
+
+func bunSelfUpdateSkipMessage(owner bunInstallOwner) string {
+	switch owner {
+	case bunOwnerHomebrew:
+		return "Bun 本体は Homebrew 管理のため bun upgrade をスキップします"
+	case bunOwnerScoop:
+		return "Bun 本体は Scoop 管理のため bun upgrade をスキップします"
+	default:
+		return "Bun 本体のインストール経路を安全に判定できないため bun upgrade をスキップします"
+	}
+}
+
+func detectBunInstallOwner(bunPath string) bunInstallOwner {
+	resolvedPath, err := filepath.EvalSymlinks(bunPath)
+	if err != nil {
+		resolvedPath = bunPath
+	}
+
+	homeDir, homeErr := os.UserHomeDir()
+	if homeErr != nil {
+		homeDir = ""
+	}
+
+	return classifyBunInstallOwner(
+		bunPath,
+		resolvedPath,
+		os.Getenv("BUN_INSTALL"),
+		homeDir,
+		os.Getenv("SCOOP"),
+	)
+}
+
+func classifyBunInstallOwner(bunPath, resolvedPath, bunInstallDir, homeDir, scoopDir string) bunInstallOwner {
+	paths := []string{normalizePortablePath(bunPath), normalizePortablePath(resolvedPath)}
+
+	for _, candidate := range paths {
+		if isHomebrewBunPath(candidate) {
+			return bunOwnerHomebrew
+		}
+
+		if isScoopBunPath(candidate, scoopDir, homeDir) {
+			return bunOwnerScoop
+		}
+	}
+
+	for _, candidate := range paths {
+		if isBunManagedPath(candidate, bunInstallDir, homeDir) {
+			return bunOwnerSelf
+		}
+	}
+
+	return bunOwnerUnknown
+}
+
+func isHomebrewBunPath(candidate string) bool {
+	return strings.Contains(candidate, "/cellar/bun/") ||
+		strings.HasSuffix(candidate, "/homebrew/bin/bun") ||
+		strings.HasSuffix(candidate, "/homebrew/bin/bun.exe") ||
+		strings.HasSuffix(candidate, "/.linuxbrew/bin/bun") ||
+		strings.HasSuffix(candidate, "/.linuxbrew/bin/bun.exe")
+}
+
+func isScoopBunPath(candidate, scoopDir, homeDir string) bool {
+	if pathWithinPortable(candidate, normalizePortablePath(scoopDir)) {
+		return true
+	}
+
+	defaultRoot := path.Join(normalizePortablePath(homeDir), "scoop")
+	if pathWithinPortable(candidate, defaultRoot) {
+		return true
+	}
+
+	return strings.Contains(candidate, "/scoop/apps/bun/") ||
+		strings.HasSuffix(candidate, "/scoop/shims/bun") ||
+		strings.HasSuffix(candidate, "/scoop/shims/bun.exe")
+}
+
+func isBunManagedPath(candidate, bunInstallDir, homeDir string) bool {
+	if pathWithinPortable(candidate, path.Join(normalizePortablePath(bunInstallDir), "bin")) {
+		return true
+	}
+
+	return pathWithinPortable(candidate, path.Join(normalizePortablePath(homeDir), ".bun", "bin"))
+}
+
+func normalizePortablePath(value string) string {
+	normalized := strings.ReplaceAll(strings.TrimSpace(value), "\\", "/")
+	if normalized == "" {
+		return ""
+	}
+
+	return strings.ToLower(path.Clean(normalized))
+}
+
+func pathWithinPortable(candidate, root string) bool {
+	if candidate == "" || root == "" || root == "." || root == "/" {
+		return false
+	}
+
+	return candidate == root || strings.HasPrefix(candidate, strings.TrimSuffix(root, "/")+"/")
+}
+
+func (b *BunUpdater) lookPath(name string) (string, error) {
+	if b.lookPathStep != nil {
+		return b.lookPathStep(name)
+	}
+
+	return exec.LookPath(name)
+}
+
+func (b *BunUpdater) detectOwner(bunPath string) bunInstallOwner {
+	if b.detectOwnerStep != nil {
+		return b.detectOwnerStep(bunPath)
+	}
+
+	return detectBunInstallOwner(bunPath)
+}
+
+func (b *BunUpdater) fetchRelease(ctx context.Context, currentVersion string) (latestVersion, releaseURL string, err error) {
+	if b.fetchReleaseStep != nil {
+		return b.fetchReleaseStep(ctx, currentVersion)
+	}
+
+	return selfupdate.FetchGitHubLatestRelease(ctx, bunLatestReleaseAPI, "dsx-bun-updater/"+currentVersion)
+}
+
+func (b *BunUpdater) runOutput(ctx context.Context, args ...string) ([]byte, error) {
+	if b.runOutputStep != nil {
+		return b.runOutputStep(ctx, args...)
+	}
+
+	cmd := exec.CommandContext(ctx, "bun", args...)
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, buildCommandOutputErr(err, output)
+	}
+
+	return output, nil
+}
+
+func (b *BunUpdater) runInteractive(ctx context.Context, args ...string) error {
+	if b.runInteractiveStep != nil {
+		return b.runInteractiveStep(ctx, args...)
+	}
+
+	cmd := exec.CommandContext(ctx, "bun", args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Stdin = os.Stdin
+
+	return cmd.Run()
+}
+
+var _ Updater = (*BunUpdater)(nil)
+var _ ManagerSelfUpdater = (*BunUpdater)(nil)

--- a/internal/updater/bun_test.go
+++ b/internal/updater/bun_test.go
@@ -1,0 +1,603 @@
+package updater
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/scottlz0310/dsx/internal/config"
+)
+
+func TestBunUpdaterMetadata(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{name: "Name", got: (&BunUpdater{}).Name(), want: "bun"},
+		{name: "DisplayName", got: (&BunUpdater{}).DisplayName(), want: "Bun (JavaScript/TypeScript グローバルパッケージ)"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if tt.got != tt.want {
+				t.Fatalf("got = %q, want %q", tt.got, tt.want)
+			}
+		})
+	}
+
+	if err := (&BunUpdater{}).Configure(config.ManagerConfig{"dummy": true}); err != nil {
+		t.Fatalf("Configure() error = %v", err)
+	}
+}
+
+func TestBunUpdaterIsAvailable(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		lookErr error
+		want    bool
+	}{
+		{name: "bunが見つかる", want: true},
+		{name: "bunが見つからない", lookErr: errors.New("not found"), want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			updater := &BunUpdater{
+				lookPathStep: func(name string) (string, error) {
+					if name != "bun" {
+						t.Fatalf("lookPath name = %q, want bun", name)
+					}
+
+					return "/tools/bun", tt.lookErr
+				},
+			}
+
+			if got := updater.IsAvailable(); got != tt.want {
+				t.Fatalf("IsAvailable() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseBunOutdatedOutput(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		output      string
+		want        []PackageInfo
+		wantErrText string
+	}{
+		{
+			name: "通常出力",
+			output: `bun outdated v1.3.14 (0d9b296a)
+|---------------------------------------|
+| Package  | Current | Update  | Latest |
+|----------|---------|---------|--------|
+| npm      | 11.7.0  | 11.18.0 | 12.0.1 |
+|---------------------------------------|`,
+			want: []PackageInfo{{Name: "npm", CurrentVersion: "11.7.0", NewVersion: "12.0.1"}},
+		},
+		{
+			name: "scope付きパッケージと複数行",
+			output: `| Package        | Current | Update | Latest |
+|----------------|---------|--------|--------|
+| @scope/tool    | 1.0.0   | 1.1.0  | 2.0.0  |
+| plain-tool     | 3.0.0   | 3.0.1  | 3.0.1  |`,
+			want: []PackageInfo{
+				{Name: "@scope/tool", CurrentVersion: "1.0.0", NewVersion: "2.0.0"},
+				{Name: "plain-tool", CurrentVersion: "3.0.0", NewVersion: "3.0.1"},
+			},
+		},
+		{
+			name: "Unicode罫線",
+			output: `┌─────────┬─────────┬────────┬────────┐
+│ Package │ Current │ Update │ Latest │
+├─────────┼─────────┼────────┼────────┤
+│ tool    │ 1.0.0   │ 1.1.0  │ 2.0.0  │
+└─────────┴─────────┴────────┴────────┘`,
+			want: []PackageInfo{{Name: "tool", CurrentVersion: "1.0.0", NewVersion: "2.0.0"}},
+		},
+		{name: "空出力", output: "", want: []PackageInfo{}},
+		{name: "最新版はバナーのみ", output: "bun outdated v1.3.14 (0d9b296a)\n", want: []PackageInfo{}},
+		{
+			name: "列不足",
+			output: `| Package | Current | Update | Latest |
+| broken  | 1.0.0   | 2.0.0  |`,
+			wantErrText: "列数が不正",
+		},
+		{
+			name: "最新バージョンが空",
+			output: `| Package | Current | Update | Latest |
+| broken  | 1.0.0   | 1.1.0  |        |`,
+			wantErrText: "必須列が空",
+		},
+		{name: "未知の形式", output: "unexpected output", wantErrText: "ヘッダーを認識できません"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := parseBunOutdatedOutput(tt.output)
+			if tt.wantErrText != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErrText) {
+					t.Fatalf("parseBunOutdatedOutput() error = %v, want contains %q", err, tt.wantErrText)
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("parseBunOutdatedOutput() error = %v", err)
+			}
+
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("parseBunOutdatedOutput() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestClassifyBunInstallOwner(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		bunPath       string
+		resolvedPath  string
+		bunInstallDir string
+		homeDir       string
+		scoopDir      string
+		want          bunInstallOwner
+	}{
+		{
+			name:          "BUN_INSTALL配下",
+			bunPath:       `D:\tools\bun\bin\bun.exe`,
+			resolvedPath:  `D:\tools\bun\bin\bun.exe`,
+			bunInstallDir: `D:\tools\bun`,
+			homeDir:       `C:\Users\dev`,
+			want:          bunOwnerSelf,
+		},
+		{
+			name:         "デフォルトのbun管理パス",
+			bunPath:      "/home/dev/.bun/bin/bun",
+			resolvedPath: "/home/dev/.bun/bin/bun",
+			homeDir:      "/home/dev",
+			want:         bunOwnerSelf,
+		},
+		{
+			name:         "Homebrewの解決先",
+			bunPath:      "/opt/homebrew/bin/bun",
+			resolvedPath: "/opt/homebrew/Cellar/bun/1.3.14/bin/bun",
+			homeDir:      "/Users/dev",
+			want:         bunOwnerHomebrew,
+		},
+		{
+			name:         "Linuxbrewのshim",
+			bunPath:      "/home/linuxbrew/.linuxbrew/bin/bun",
+			resolvedPath: "/home/linuxbrew/.linuxbrew/bin/bun",
+			homeDir:      "/home/dev",
+			want:         bunOwnerHomebrew,
+		},
+		{
+			name:         "Scoopのデフォルトshim",
+			bunPath:      `C:\Users\dev\scoop\shims\bun.exe`,
+			resolvedPath: `C:\Users\dev\scoop\shims\bun.exe`,
+			homeDir:      `C:\Users\dev`,
+			want:         bunOwnerScoop,
+		},
+		{
+			name:         "Scoopのカスタムルート",
+			bunPath:      `D:\packages\shims\bun.exe`,
+			resolvedPath: `D:\packages\shims\bun.exe`,
+			homeDir:      `C:\Users\dev`,
+			scoopDir:     `D:\packages`,
+			want:         bunOwnerScoop,
+		},
+		{
+			name:         "所有元不明",
+			bunPath:      "/usr/local/bin/bun",
+			resolvedPath: "/usr/local/bin/bun",
+			homeDir:      "/home/dev",
+			want:         bunOwnerUnknown,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := classifyBunInstallOwner(tt.bunPath, tt.resolvedPath, tt.bunInstallDir, tt.homeDir, tt.scoopDir)
+			if got != tt.want {
+				t.Fatalf("classifyBunInstallOwner() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBunUpdaterCheck(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		output      string
+		runErr      error
+		wantCount   int
+		wantErrText string
+	}{
+		{
+			name:      "更新あり",
+			output:    "| Package | Current | Update | Latest |\n| tool | 1.0.0 | 1.1.0 | 2.0.0 |\n",
+			wantCount: 1,
+		},
+		{name: "更新なし", output: "bun outdated v1.3.14\n"},
+		{name: "コマンド失敗", runErr: errors.New("network error"), wantErrText: "bun outdated -g の実行に失敗"},
+		{name: "解析失敗", output: "invalid", wantErrText: "bun outdated -g の出力解析に失敗"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			updater := &BunUpdater{
+				runOutputStep: func(_ context.Context, args ...string) ([]byte, error) {
+					if strings.Join(args, " ") != "outdated -g" {
+						t.Fatalf("args = %v, want [outdated -g]", args)
+					}
+
+					return []byte(tt.output), tt.runErr
+				},
+			}
+
+			got, err := updater.Check(context.Background())
+			if tt.wantErrText != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErrText) {
+					t.Fatalf("Check() error = %v, want contains %q", err, tt.wantErrText)
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("Check() error = %v", err)
+			}
+
+			if got.AvailableUpdates != tt.wantCount {
+				t.Fatalf("AvailableUpdates = %d, want %d", got.AvailableUpdates, tt.wantCount)
+			}
+		})
+	}
+}
+
+func TestBunUpdaterUpdate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		outdatedOutput  string
+		dryRun          bool
+		interactiveErr  error
+		wantRun         bool
+		wantUpdated     int
+		wantMessageText string
+		wantErrText     string
+	}{
+		{
+			name:            "更新なし",
+			outdatedOutput:  "bun outdated v1.3.14\n",
+			wantMessageText: "最新です",
+		},
+		{
+			name:            "dry-runでは更新しない",
+			outdatedOutput:  bunOutdatedOnePackage,
+			dryRun:          true,
+			wantMessageText: "DryRunモード",
+		},
+		{
+			name:            "latestまで更新",
+			outdatedOutput:  bunOutdatedOnePackage,
+			wantRun:         true,
+			wantUpdated:     1,
+			wantMessageText: "更新しました",
+		},
+		{
+			name:           "更新コマンド失敗",
+			outdatedOutput: bunOutdatedOnePackage,
+			interactiveErr: errors.New("update failed"),
+			wantRun:        true,
+			wantErrText:    "bun update -g --latest に失敗",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			runCalled := false
+			updater := &BunUpdater{
+				runOutputStep: func(_ context.Context, args ...string) ([]byte, error) {
+					return []byte(tt.outdatedOutput), nil
+				},
+				runInteractiveStep: func(_ context.Context, args ...string) error {
+					runCalled = true
+
+					if strings.Join(args, " ") != "update -g --latest" {
+						t.Fatalf("args = %v, want [update -g --latest]", args)
+					}
+
+					return tt.interactiveErr
+				},
+			}
+
+			got, err := updater.Update(context.Background(), UpdateOptions{DryRun: tt.dryRun})
+			if tt.wantErrText != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErrText) {
+					t.Fatalf("Update() error = %v, want contains %q", err, tt.wantErrText)
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("Update() error = %v", err)
+			}
+
+			if runCalled != tt.wantRun {
+				t.Fatalf("runCalled = %v, want %v", runCalled, tt.wantRun)
+			}
+
+			if got.UpdatedCount != tt.wantUpdated {
+				t.Fatalf("UpdatedCount = %d, want %d", got.UpdatedCount, tt.wantUpdated)
+			}
+
+			if !strings.Contains(got.Message, tt.wantMessageText) {
+				t.Fatalf("Message = %q, want contains %q", got.Message, tt.wantMessageText)
+			}
+		})
+	}
+}
+
+func TestBunUpdaterCheckSelfUpdate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		owner            bunInstallOwner
+		currentVersion   string
+		latestVersion    string
+		versionErr       error
+		fetchErr         error
+		wantCount        int
+		wantMessageText  string
+		wantErrText      string
+		wantVersionCalls int
+		wantFetchCalls   int
+	}{
+		{name: "Homebrew管理", owner: bunOwnerHomebrew, wantMessageText: "Homebrew 管理"},
+		{name: "Scoop管理", owner: bunOwnerScoop, wantMessageText: "Scoop 管理"},
+		{name: "所有元不明", owner: bunOwnerUnknown, wantMessageText: "安全に判定できない"},
+		{
+			name:             "Bun管理で最新版",
+			owner:            bunOwnerSelf,
+			currentVersion:   "1.3.14\n",
+			latestVersion:    "bun-v1.3.14",
+			wantMessageText:  "最新です",
+			wantVersionCalls: 1,
+			wantFetchCalls:   1,
+		},
+		{
+			name:             "Bun管理で更新あり",
+			owner:            bunOwnerSelf,
+			currentVersion:   "1.3.13\n",
+			latestVersion:    "bun-v1.3.14",
+			wantCount:        1,
+			wantMessageText:  "更新が可能",
+			wantVersionCalls: 1,
+			wantFetchCalls:   1,
+		},
+		{
+			name:             "現在バージョン取得失敗",
+			owner:            bunOwnerSelf,
+			versionErr:       errors.New("version failed"),
+			wantErrText:      "bun --version の実行に失敗",
+			wantVersionCalls: 1,
+		},
+		{
+			name:             "現在バージョン不正",
+			owner:            bunOwnerSelf,
+			currentVersion:   "invalid",
+			wantErrText:      "現在バージョンを解析できません",
+			wantVersionCalls: 1,
+		},
+		{
+			name:             "最新リリース取得失敗",
+			owner:            bunOwnerSelf,
+			currentVersion:   "1.3.13",
+			fetchErr:         errors.New("api failed"),
+			wantErrText:      "最新リリース取得に失敗",
+			wantVersionCalls: 1,
+			wantFetchCalls:   1,
+		},
+		{
+			name:             "最新バージョン不正",
+			owner:            bunOwnerSelf,
+			currentVersion:   "1.3.13",
+			latestVersion:    "invalid",
+			wantErrText:      "最新バージョンを解析できません",
+			wantVersionCalls: 1,
+			wantFetchCalls:   1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			versionCalls := 0
+			fetchCalls := 0
+			updater := &BunUpdater{
+				lookPathStep:    func(string) (string, error) { return "/tools/bun", nil },
+				detectOwnerStep: func(string) bunInstallOwner { return tt.owner },
+				runOutputStep: func(_ context.Context, args ...string) ([]byte, error) {
+					versionCalls++
+
+					if strings.Join(args, " ") != "--version" {
+						t.Fatalf("args = %v, want [--version]", args)
+					}
+
+					return []byte(tt.currentVersion), tt.versionErr
+				},
+				fetchReleaseStep: func(_ context.Context, _ string) (string, string, error) {
+					fetchCalls++
+
+					return tt.latestVersion, "https://example.com", tt.fetchErr
+				},
+			}
+
+			got, err := updater.CheckSelfUpdate(context.Background())
+			if tt.wantErrText != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErrText) {
+					t.Fatalf("CheckSelfUpdate() error = %v, want contains %q", err, tt.wantErrText)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("CheckSelfUpdate() error = %v", err)
+				}
+
+				if got.AvailableUpdates != tt.wantCount {
+					t.Fatalf("AvailableUpdates = %d, want %d", got.AvailableUpdates, tt.wantCount)
+				}
+
+				if !strings.Contains(got.Message, tt.wantMessageText) {
+					t.Fatalf("Message = %q, want contains %q", got.Message, tt.wantMessageText)
+				}
+			}
+
+			if versionCalls != tt.wantVersionCalls {
+				t.Fatalf("versionCalls = %d, want %d", versionCalls, tt.wantVersionCalls)
+			}
+
+			if fetchCalls != tt.wantFetchCalls {
+				t.Fatalf("fetchCalls = %d, want %d", fetchCalls, tt.wantFetchCalls)
+			}
+		})
+	}
+}
+
+func TestBunUpdaterSelfUpdate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		owner           bunInstallOwner
+		dryRun          bool
+		interactiveErr  error
+		wantRun         bool
+		wantUpdated     int
+		wantMessageText string
+		wantErrText     string
+	}{
+		{
+			name:            "所有元不明はスキップして継続",
+			owner:           bunOwnerUnknown,
+			wantMessageText: "安全に判定できない",
+		},
+		{
+			name:            "dry-runではupgradeしない",
+			owner:           bunOwnerSelf,
+			dryRun:          true,
+			wantMessageText: "DryRunモード",
+		},
+		{
+			name:            "bun upgradeを実行",
+			owner:           bunOwnerSelf,
+			wantRun:         true,
+			wantUpdated:     1,
+			wantMessageText: "更新しました",
+		},
+		{
+			name:           "bun upgrade失敗",
+			owner:          bunOwnerSelf,
+			interactiveErr: errors.New("upgrade failed"),
+			wantRun:        true,
+			wantErrText:    "bun upgrade に失敗",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			runCalled := false
+			updater := &BunUpdater{
+				lookPathStep:    func(string) (string, error) { return "/tools/bun", nil },
+				detectOwnerStep: func(string) bunInstallOwner { return tt.owner },
+				runOutputStep: func(_ context.Context, args ...string) ([]byte, error) {
+					if strings.Join(args, " ") != "--version" {
+						return nil, fmt.Errorf("unexpected args: %v", args)
+					}
+
+					return []byte("1.3.13"), nil
+				},
+				fetchReleaseStep: func(context.Context, string) (string, string, error) {
+					return "bun-v1.3.14", "https://example.com", nil
+				},
+				runInteractiveStep: func(_ context.Context, args ...string) error {
+					runCalled = true
+
+					if strings.Join(args, " ") != "upgrade" {
+						t.Fatalf("args = %v, want [upgrade]", args)
+					}
+
+					return tt.interactiveErr
+				},
+			}
+
+			got, err := updater.SelfUpdate(context.Background(), UpdateOptions{DryRun: tt.dryRun})
+			if tt.wantErrText != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErrText) {
+					t.Fatalf("SelfUpdate() error = %v, want contains %q", err, tt.wantErrText)
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("SelfUpdate() error = %v", err)
+			}
+
+			if runCalled != tt.wantRun {
+				t.Fatalf("runCalled = %v, want %v", runCalled, tt.wantRun)
+			}
+
+			if got.UpdatedCount != tt.wantUpdated {
+				t.Fatalf("UpdatedCount = %d, want %d", got.UpdatedCount, tt.wantUpdated)
+			}
+
+			if got.Continuation != ContinueNormalUpdate {
+				t.Fatalf("Continuation = %q, want %q", got.Continuation, ContinueNormalUpdate)
+			}
+
+			if !strings.Contains(got.Message, tt.wantMessageText) {
+				t.Fatalf("Message = %q, want contains %q", got.Message, tt.wantMessageText)
+			}
+		})
+	}
+}
+
+const bunOutdatedOnePackage = `| Package | Current | Update | Latest |
+| tool    | 1.0.0   | 1.1.0 | 2.0.0  |
+`

--- a/internal/updater/constants.go
+++ b/internal/updater/constants.go
@@ -3,5 +3,6 @@ package updater
 const (
 	allPackagesUpToDateMessage = "すべてのパッケージは最新です"
 	updateCommand              = "update"
+	upgradeCommand             = "upgrade"
 	latestVersionSuffix        = "@latest"
 )

--- a/internal/updater/uv.go
+++ b/internal/updater/uv.go
@@ -156,7 +156,7 @@ func (u *UVUpdater) Update(ctx context.Context, opts UpdateOptions) (*UpdateResu
 		return result, nil
 	}
 
-	cmd := exec.CommandContext(ctx, "uv", "tool", "upgrade", "--all")
+	cmd := exec.CommandContext(ctx, "uv", "tool", upgradeCommand, "--all")
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.Stdin = os.Stdin

--- a/internal/updater/winget.go
+++ b/internal/updater/winget.go
@@ -37,7 +37,7 @@ func (w *WingetUpdater) Configure(cfg config.ManagerConfig) error {
 }
 
 func (w *WingetUpdater) Check(ctx context.Context) (*CheckResult, error) {
-	cmd := exec.CommandContext(ctx, "winget", "upgrade", "--include-unknown", "--disable-interactivity", "--accept-source-agreements")
+	cmd := exec.CommandContext(ctx, "winget", upgradeCommand, "--include-unknown", "--disable-interactivity", "--accept-source-agreements")
 
 	// stderr も含めた出力を取得することで、エラー時の診断情報を失わないようにする。
 	// winget はアップグレード可能なパッケージがある場合も exit code 0 以外を返すことがあるため、
@@ -71,7 +71,7 @@ func (w *WingetUpdater) Update(ctx context.Context, opts UpdateOptions) (*Update
 			return fmt.Sprintf("%d 件の winget パッケージが更新可能です（DryRunモード）", count)
 		},
 		"winget",
-		[]string{"upgrade", "--all", "--include-unknown", "--disable-interactivity", "--accept-source-agreements", "--accept-package-agreements"},
+		[]string{upgradeCommand, "--all", "--include-unknown", "--disable-interactivity", "--accept-source-agreements", "--accept-package-agreements"},
 		"winget upgrade --all に失敗: %w",
 		func(count int) string {
 			return fmt.Sprintf("%d 件の winget パッケージを更新しました", count)

--- a/tasks.md
+++ b/tasks.md
@@ -263,6 +263,19 @@
 
 ---
 
+## Issue #96: Bun のグローバルツール更新とマネージャ本体更新
+
+- [x] `BunUpdater` を updater レジストリへ追加
+- [x] `bun outdated -g` / `bun update -g --latest` によるグローバルパッケージ更新に対応
+- [x] Bun 管理のインストールで `bun upgrade` による本体更新に対応
+- [x] Homebrew / Scoop 管理下または所有元不明の本体更新を安全にスキップ
+- [x] dry-run、出力 parser、境界値、失敗系、インストール経路判定を table-driven tests で固定
+- [x] `config init` / `sys update --help` / `sys list` に Bun を統合
+- [x] `CHANGELOG.md` / `README.md` / `tasks.md` / `docs/Implementation_Plan.md` を更新
+- [x] `task test` / `task check` / `go build ./...` / `dsx --help` の検証
+
+---
+
 ## v0.7.0 リリース準備
 
 - [x] PR #82 が main にマージ済みであることを確認


### PR DESCRIPTION
## 概要

Issue #96 に基づき、`dsx sys update` で Bun のグローバルパッケージと Bun 本体を更新できるようにします。

## 変更内容

- `BunUpdater` を updater レジストリへ追加
  - `bun outdated -g` で latest との差分を確認
  - `bun update -g --latest` でグローバルパッケージを更新
  - ASCII / Unicode の表形式出力を解析
- 既存の `ManagerSelfUpdater` へ Bun 本体更新を統合
  - Bun 管理のインストールでは GitHub Releases の stable 版と比較して `bun upgrade`
  - Homebrew / Scoop 管理下または所有元不明では本体更新を安全にスキップ
  - dry-run では副作用のある `bun upgrade` を実行しない
- Homebrew / Scoop による Bun 本体更新と `bun update -g` の競合を避けるため、Bun updater を通常の並列フェーズより先に単独実行
- `config init`、`sys update --help`、README、CHANGELOG、tasks、実装計画へ Bun を追加
- parser、境界値、エラー、dry-run、インストール経路、更新継続を table-driven tests で固定

変更量の大半は Bun CLI 出力とインストール経路の境界・失敗系を固定するテストです。

## ユーザーへの影響

`sys.enable` に `bun` を追加すると、Bun で導入したグローバル CLI を latest まで更新できます。Bun 本体は所有元を安全に判定できる場合だけ更新されるため、Homebrew / Scoop との二重更新を避けます。

## 検証

- `task test`
- `task check`（gofmt / go vet / 全テスト / golangci-lint）
- `go build ./...`
- `go run ./cmd/dsx --help`
- `go run ./cmd/dsx sys update --help`
- pre-push hook（lint / test）

Closes #96