### PR TITLE
chore: v0.8.0 のリリース準備

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ## [Unreleased]
 
+## [v0.8.0] - 2026-07-16
+
 ### Added
 
 - `dsx sys update` に Bun updater を追加。`bun outdated -g` / `bun update -g --latest` によるグローバルパッケージ更新と、Bun 管理のインストールに対する `bun upgrade` に対応し、Homebrew / Scoop 管理下または所有元不明の本体更新は安全にスキップする（#96）
@@ -404,7 +406,8 @@
 
 ---
 
-[Unreleased]: https://github.com/scottlz0310/dsx/compare/v0.7.0...HEAD
+[Unreleased]: https://github.com/scottlz0310/dsx/compare/v0.8.0...HEAD
+[v0.8.0]: https://github.com/scottlz0310/dsx/compare/v0.7.0...v0.8.0
 [v0.7.0]: https://github.com/scottlz0310/dsx/compare/v0.6.4...v0.7.0
 [v0.6.4]: https://github.com/scottlz0310/dsx/compare/v0.6.3...v0.6.4
 [v0.6.3]: https://github.com/scottlz0310/dsx/compare/v0.6.2...v0.6.3

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ dsx は、開発環境の運用作業を統合・一元化するためのクロ�
 [Releases ページ](https://github.com/scottlz0310/dsx/releases) からお使いの OS 向けのバイナリをダウンロードして PATH に配置してください。
 
 ```bash
-# 例: Linux amd64（v0.7.0 の場合）
-curl -Lo dsx.tar.gz https://github.com/scottlz0310/dsx/releases/download/v0.7.0/dsx_0.7.0_linux_amd64.tar.gz
+# 例: Linux amd64（v0.8.0 の場合）
+curl -Lo dsx.tar.gz https://github.com/scottlz0310/dsx/releases/download/v0.8.0/dsx_0.8.0_linux_amd64.tar.gz
 tar xzf dsx.tar.gz
 sudo mv dsx /usr/local/bin/
 ```
@@ -157,7 +157,7 @@ Remove-Item -Force (Get-Command dsx).Source
 
 ### メインコマンド
 ```
-dsx --version      # バージョン表示（現在: v0.7.0）
+dsx --version      # バージョン表示（現在: v0.8.0）
 dsx run           # 日次の統合タスクを実行（Bitwarden解錠→環境変数読込→更新処理）
 dsx run -n        # ドライラン（sys/repo に伝播）
 dsx run --tui     # TUI 進捗表示を有効化（sys/repo に伝播）
@@ -292,26 +292,26 @@ dsx config validate   # 設定内容を検証
 dsx config uninstall  # シェル設定からdsxを削除
 ```
 
-## 📋 リリース方針（v0.7.0）
+## 📋 リリース方針（v0.8.0）
 
-本バージョンは **`dsx sys update` のマネージャ本体更新フェーズ** を追加する機能強化リリースです。
+本バージョンは **Bun のグローバルパッケージ更新と本体更新** に対応する機能強化リリースです。
 
 ### 主な変更
 
-- `sys update` の通常更新前に、対応マネージャの本体更新を中央フローで実行
-- `uv` は `uv self update --dry-run` / `uv self update` に対応し、非対応のインストール経路では安全にスキップ
-- `pnpm` のグローバル更新を `pnpm update -g --latest` に変更
+- `bun outdated -g` / `bun update -g --latest` によるグローバルパッケージ更新に対応
+- Bun 管理のインストールでは、通常更新前に `bun upgrade` で本体を更新
+- Homebrew / Scoop 管理下または所有元不明の Bun 本体更新は、安全のためスキップ
 
 ### 推奨運用（当面）
 
-- `dsx sys update -n --tui` で、マネージャ本体更新と通常更新の予定を先に確認する
-- `uv self update` が使えないインストール経路では、表示メッセージを確認したうえで通常更新フェーズを継続する
+- `dsx sys update -n --tui` で、Bun 本体更新とグローバルパッケージ更新の予定を先に確認する
+- Homebrew / Scoop で導入した Bun は、それぞれのパッケージマネージャで本体を更新する
 - `dsx` 本体更新は従来通り `dsx self-update` で実行する
 
 ### 既知の制約
 
-- マネージャ本体更新フェーズは任意インターフェース対応済みの updater のみ対象
-- `uv self update` は uv のインストール経路によって利用できない場合がある
+- Bun 本体の所有元を特定できない場合は、自動更新を行わない
+- Bun のグローバル更新は、実行環境に `bun` がインストールされている場合のみ対象
 - `sys` パッケージマネージャ対応は拡張中（追加対応は `tasks.md` 管理）
 
 ## 🧪 日常運用（マニュアルテスト手順）
@@ -535,7 +535,7 @@ task lint
 
 ## 📅 ステータス
 
-現在 **v0.7.0（安定版）** です。
+現在 **v0.8.0（安定版）** です。
 詳細なロードマップについては [docs/Implementation_Plan.md](docs/Implementation_Plan.md) を参照してください。
 
 ## 📄 ライセンス

--- a/tasks.md
+++ b/tasks.md
@@ -299,7 +299,7 @@
 - [x] `task release:check` 通過
 - [x] CHANGELOG.md: [Unreleased] → [v0.8.0] - 2026-07-16
 - [x] README.md: バージョン表記とリリース方針を v0.8.0 に更新
-- [ ] リリース準備 PR をレビューレディで作成
+- [x] リリース準備 PR #98 をレビューレディで作成
 - [ ] `v0.8.0` タグ発行・push → goreleaser が GitHub Release を自動作成
 
 ---

--- a/tasks.md
+++ b/tasks.md
@@ -286,7 +286,21 @@
 - [ ] タグ push 後の Release workflow で `go test -race ./...` 通過を確認（ローカル Windows は gcc 未導入のため未実施）
 - [x] CHANGELOG.md: [Unreleased] → [v0.7.0] - 2026-05-30
 - [x] README.md: バージョン表記を v0.7.0 に更新
-- [ ] `v0.7.0` タグ発行・push → goreleaser が GitHub Release を自動作成
+- [x] `v0.7.0` タグ発行・push → goreleaser が GitHub Release を自動作成
+
+---
+
+## v0.8.0 リリース準備
+
+- [x] PR #97 が main にマージ済みであることを確認
+- [x] `task check` 通過（fmt/vet/test/lint）
+- [x] `go build ./...` 通過
+- [x] `go run ./cmd/dsx --help` 表示確認
+- [x] `task release:check` 通過
+- [x] CHANGELOG.md: [Unreleased] → [v0.8.0] - 2026-07-16
+- [x] README.md: バージョン表記とリリース方針を v0.8.0 に更新
+- [ ] リリース準備 PR をレビューレディで作成
+- [ ] `v0.8.0` タグ発行・push → goreleaser が GitHub Release を自動作成
 
 ---
 


### PR DESCRIPTION
## 概要

- `CHANGELOG.md` の未リリース変更を `v0.8.0`（2026-07-16）として確定
- `README.md` のインストール例、バージョン表記、リリース方針を Bun 対応に更新
- `tasks.md` に v0.8.0 のリリース準備状況を反映

## 背景

Bun のグローバルパッケージ更新と、インストール経路に応じた Bun 本体更新が main に追加されたため、機能追加リリースとして v0.8.0 を準備します。

## 影響

ドキュメントと進捗管理のみの変更です。マージ後に `v0.8.0` タグを発行すると、Release workflow が GoReleaser による GitHub Release を作成します。

## 検証

- `task check`
- `go build ./...`
- `go run ./cmd/dsx --help`
- `task release:check`（GoReleaser v2.17.0）
- pre-push hook（lint / test）