### PR TITLE
fix(updater/pnpm): pnpm update -g 実行時のインタラクティブプロンプトによるタイムアウトの防止

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- `pnpm` のグローバル更新実行時 (`pnpm update -g --latest`) に `--no-interactive` フラグと `CI=true` 環境変数を追加し、無人・自動実行時の対話プロンプトによるタイムアウトを防止（#101）
+
 ## [v0.8.0] - 2026-07-16
 
 ### Added

--- a/internal/updater/pnpm.go
+++ b/internal/updater/pnpm.go
@@ -142,7 +142,9 @@ func (p *PnpmUpdater) Update(ctx context.Context, opts UpdateOptions) (*UpdateRe
 }
 
 func (p *PnpmUpdater) runUpdate(ctx context.Context) error {
-	cmd := exec.CommandContext(ctx, "pnpm", "update", "-g", "--latest")
+	cmd := exec.CommandContext(ctx, "pnpm", "update", "-g", "--latest", "--no-interactive")
+
+	cmd.Env = append(os.Environ(), "CI=true")
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.Stdin = os.Stdin

--- a/internal/updater/pnpm_test.go
+++ b/internal/updater/pnpm_test.go
@@ -660,6 +660,14 @@ if "%subcmd%"=="update" (
     >&2 echo missing --latest
     exit /b 1
   )
+  if not "%4"=="--no-interactive" (
+    >&2 echo missing --no-interactive
+    exit /b 1
+  )
+  if not "%CI%"=="true" (
+    >&2 echo missing CI=true
+    exit /b 1
+  )
   if "%DSX_TEST_PNPM_MODE%"=="update_fail" (
     goto updatefail
   )
@@ -740,6 +748,14 @@ if [ "${subcmd}" = "update" ]; then
   fi
   if [ "$3" != "--latest" ]; then
     echo 'missing --latest' 1>&2
+    exit 1
+  fi
+  if [ "$4" != "--no-interactive" ]; then
+    echo 'missing --no-interactive' 1>&2
+    exit 1
+  fi
+  if [ "${CI}" != "true" ]; then
+    echo 'missing CI=true' 1>&2
     exit 1
   fi
   if [ "${mode}" = "update_fail" ]; then

--- a/tasks.md
+++ b/tasks.md
@@ -10,7 +10,7 @@
 - [x] `internal/updater/pnpm_test.go` に `--no-interactive` フラグと `CI=true` のテスト検証を追加
 - [x] `CHANGELOG.md` 更新
 - [x] `task check` 通過
-- [ ] コミット・push & PR 作成
+- [x] コミット・push & PR #102 作成
 
 ---
 

--- a/tasks.md
+++ b/tasks.md
@@ -4,6 +4,14 @@
 
 > 過去の完了タスク履歴は [docs/archive/tasks_v0.2.3.md](docs/archive/tasks_v0.2.3.md) を参照してください。
 
+## Issue #101: pnpm update -g 実行時のインタラクティブプロンプトによるタイムアウト防止
+
+- [x] `internal/updater/pnpm.go` に `--no-interactive` フラグおよび `CI=true` 環境変数を追加
+- [x] `internal/updater/pnpm_test.go` に `--no-interactive` フラグと `CI=true` のテスト検証を追加
+- [x] `CHANGELOG.md` 更新
+- [x] `task check` 通過
+- [ ] コミット・push & PR 作成
+
 ---
 
 ## Issue #1: dsx repo branch-clean サブコマンド実装


### PR DESCRIPTION
## 概要

Closes #101

`pnpm update -g --latest` 実行時にインタラクティブプロンプトが表示され無人・自動実行時にタイムアウトする問題を防止するため、`--no-interactive` フラグおよび環境変数 `CI=true` を追加しました。

## 変更内容

- `internal/updater/pnpm.go` の `runUpdate` で実行するコマンドに `--no-interactive` フラグを追加
- `cmd.Env` に `CI=true` を付与
- `internal/updater/pnpm_test.go` のテストで上記パラメータおよび環境変数の検証を追加
- `CHANGELOG.md` および `tasks.md` を更新