### PR TITLE
chore: v0.8.1 リリース準備

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ## [Unreleased]
 
+## [v0.8.1] - 2026-07-25
+
 ### Fixed
 
 - `pnpm` のグローバル更新実行時 (`pnpm update -g --latest`) に `--no-interactive` フラグと `CI=true` 環境変数を追加し、無人・自動実行時の対話プロンプトによるタイムアウトを防止（#101）

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ dsx は、開発環境の運用作業を統合・一元化するためのクロ�
 [Releases ページ](https://github.com/scottlz0310/dsx/releases) からお使いの OS 向けのバイナリをダウンロードして PATH に配置してください。
 
 ```bash
-# 例: Linux amd64（v0.8.0 の場合）
-curl -Lo dsx.tar.gz https://github.com/scottlz0310/dsx/releases/download/v0.8.0/dsx_0.8.0_linux_amd64.tar.gz
+# 例: Linux amd64（v0.8.1 の場合）
+curl -Lo dsx.tar.gz https://github.com/scottlz0310/dsx/releases/download/v0.8.1/dsx_0.8.1_linux_amd64.tar.gz
 tar xzf dsx.tar.gz
 sudo mv dsx /usr/local/bin/
 ```
@@ -157,7 +157,7 @@ Remove-Item -Force (Get-Command dsx).Source
 
 ### メインコマンド
 ```
-dsx --version      # バージョン表示（現在: v0.8.0）
+dsx --version      # バージョン表示（現在: v0.8.1）
 dsx run           # 日次の統合タスクを実行（Bitwarden解錠→環境変数読込→更新処理）
 dsx run -n        # ドライラン（sys/repo に伝播）
 dsx run --tui     # TUI 進捗表示を有効化（sys/repo に伝播）
@@ -292,7 +292,7 @@ dsx config validate   # 設定内容を検証
 dsx config uninstall  # シェル設定からdsxを削除
 ```
 
-## 📋 リリース方針（v0.8.0）
+## 📋 リリース方針（v0.8.1）
 
 本バージョンは **Bun のグローバルパッケージ更新と本体更新** に対応する機能強化リリースです。
 
@@ -535,7 +535,7 @@ task lint
 
 ## 📅 ステータス
 
-現在 **v0.8.0（安定版）** です。
+現在 **v0.8.1（安定版）** です。
 詳細なロードマップについては [docs/Implementation_Plan.md](docs/Implementation_Plan.md) を参照してください。
 
 ## 📄 ライセンス

--- a/tasks.md
+++ b/tasks.md
@@ -4,6 +4,20 @@
 
 > 過去の完了タスク履歴は [docs/archive/tasks_v0.2.3.md](docs/archive/tasks_v0.2.3.md) を参照してください。
 
+## v0.8.1 リリース準備
+
+- [x] PR #102 が main にマージ済みであることを確認
+- [x] `task check` 通過（fmt/vet/test/lint）
+- [x] `go build ./...` 通過
+- [x] `go run ./cmd/dsx --help` 表示確認
+- [x] `task release:check` 通過
+- [x] CHANGELOG.md: [Unreleased] → [v0.8.1] - 2026-07-25
+- [x] README.md: バージョン表記を v0.8.1 に更新
+- [x] リリース準備 PR を作成
+- [ ] `v0.8.1` タグ発行・push → goreleaser が GitHub Release を自動作成
+
+---
+
 ## Issue #101: pnpm update -g 実行時のインタラクティブプロンプトによるタイムアウト防止
 
 - [x] `internal/updater/pnpm.go` に `--no-interactive` フラグおよび `CI=true` 環境変数を追加


### PR DESCRIPTION
## 概要

v0.8.1 リリースのための準備 PR です。

## 主な変更点

- `pnpm update -g --latest` 実行時に `--no-interactive` フラグと `CI=true` 環境変数を追加し、対話プロンプトによるタイムアウトを防止（#101）
- `CHANGELOG.md`: [v0.8.1] - 2026-07-25 の更新
- `README.md`: バージョン表記を v0.8.1 に更新
- `tasks.md`: v0.8.1 リリース準備タスクの反映

## リリースチェックリスト

- [x] PR #102 が main にマージ済みであることを確認
- [x] `task check` 通過（fmt/vet/test/lint）
- [x] `go build ./...` 通過
- [x] `go run ./cmd/dsx --help` 表示確認
- [x] `task release:check` 通過（goreleaser 設定検証）
- [ ] PR マージ後、`v0.8.1` タグを発行して push → GoReleaser が GitHub Release を自動作成